### PR TITLE
Fix zod import in signup schema

### DIFF
--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { Link, Navigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import * as z from "zod";
+import { z } from "zod";
 import { User, Mail, Lock, Eye, EyeOff, Facebook, Twitter } from "lucide-react";
 
 import { useAuth } from "@/hooks/useAuth";


### PR DESCRIPTION
## Summary
- fix signup form validation by importing `z` correctly from `zod`

## Testing
- `npm run test` *(fails: vitest not found)*