### PR TITLE
Fix React useId error

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
+import { useReactId } from "@/hooks/useReactId"
 
 import { cn } from "@/lib/utils"
 
@@ -41,7 +42,7 @@ const ChartContainer = React.forwardRef<
     >["children"]
   }
 >(({ id, className, children, config, ...props }, ref) => {
-  const uniqueId = React.useId()
+  const uniqueId = useReactId()
   const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
 
   return (

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
+import { useReactId } from "@/hooks/useReactId"
 import { Slot } from "@radix-ui/react-slot"
 import {
   Controller,
@@ -74,7 +75,7 @@ const FormItem = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const id = React.useId()
+  const id = useReactId()
 
   return (
     <FormItemContext.Provider value={{ id }}>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './use-toast';
 export * from './useAuth';
 export * from './useOnboardingStatus';
 export * from './usePageViewTracking';
+export * from './useReactId';

--- a/src/hooks/useReactId.ts
+++ b/src/hooks/useReactId.ts
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+/**
+ * React 18 introduced `useId` for generating unique IDs. If an older
+ * React version is used where `useId` is unavailable, this hook provides
+ * a small fallback that mimics the API using `useRef`.
+ */
+export function useReactId(): string {
+  if (typeof (React as any).useId === "function") {
+    return (React as any).useId()
+  }
+
+  const idRef = React.useRef<string>()
+  if (!idRef.current) {
+    idRef.current = Math.random().toString(36).slice(2)
+  }
+  return idRef.current
+}


### PR DESCRIPTION
## Summary
- add a `useReactId` hook that provides a fallback when `React.useId` is not available
- export the new hook
- use the hook in chart and form components

## Testing
- `npm run test` *(fails: vitest not found)*