### PR TITLE
Fix return type for useSidebar

### DIFF
--- a/src/components/ui/sidebar/sidebar-context.tsx
+++ b/src/components/ui/sidebar/sidebar-context.tsx
@@ -10,7 +10,7 @@ const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
 const SidebarContext = React.createContext<SidebarContextType | null>(null)
 
-export function useSidebar() {
+export function useSidebar(): SidebarContextType {
   const context = React.useContext(SidebarContext)
   if (!context) {
     throw new Error("useSidebar must be used within a SidebarProvider.")


### PR DESCRIPTION
## Summary
- ensure `useSidebar` returns the correct context type

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*