### PR TITLE
Fix useNotifications return type

### DIFF
--- a/src/context/notifications/NotificationContext.tsx
+++ b/src/context/notifications/NotificationContext.tsx
@@ -21,7 +21,7 @@ const NotificationContext = createContext<NotificationContextType>(
   defaultContext
 );
 
-export const useNotifications = () => {
+export const useNotifications = (): NotificationContextType => {
   const context = useContext(NotificationContext);
   if (!context) {
     throw new Error('useNotifications must be used within a NotificationProvider');


### PR DESCRIPTION
## Summary
- ensure `useNotifications` returns typed context

## Testing
- `npm run test` *(fails: vitest not found)*