### PR TITLE
Fix signup 404 by adding root route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import Analytics from './pages/Analytics';
 import MobileLaunchPage from './pages/MobileLaunchPage';
 import CommunityPage from './pages/CommunityPage';
 import Categories from './pages/Categories';
+import Signup from './pages/Signup';
 import Login from './pages/Login';
 
 const App = () => {
@@ -38,6 +39,7 @@ const App = () => {
           <Route path="/" element={<Home />} />
           <Route path="/match" element={<AIMatcherPage />} />
           <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
           <Route path="/talent" element={<TalentDirectory />} />
           <Route path="/talents" element={<TalentsPage />} />
           <Route path="/services" element={<ServicesPage />} />


### PR DESCRIPTION
## Summary
- add `/signup` route in App router

## Testing
- `npm run test` *(fails: vitest not found)*