### PR TITLE
Fix typed theme hook usage

### DIFF
--- a/src/components/support/ChatMessage.tsx
+++ b/src/components/support/ChatMessage.tsx
@@ -3,9 +3,9 @@ import React from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
-// Import useTheme directly from the ThemeProvider to ensure TypeScript
-// picks up the correct return type for the hook
-import { useTheme } from "@/components/ThemeProvider";
+// Use the wrapper hook so TypeScript properly infers the return type
+// from the ThemeProvider context
+import { useTheme } from "@/hooks/useTheme";
 
 interface ChatMessageProps {
   message: string;


### PR DESCRIPTION
## Summary
- import `useTheme` from hooks for correct typing

## Testing
- `npm run test` *(fails: vitest not found)*