### PR TITLE
Fix rimraf warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,14 @@ If you encounter errors running `bun install` (for example, integrity check fail
 
 For pnpm errors showing "This project is configured to use npm", use `./setup.sh npm` instead as the project may have npm-specific configurations.
 
-If you see a warning about `rimraf@3.0.2` being deprecated, run:
+If you see a warning about `rimraf@3.0.2` being deprecated, install the latest
+version of `rimraf`:
 
 ```sh
-npm install rimraf@latest --save-dev
+npm install rimraf@^5 --save-dev
 ```
 
-This updates the dependency to a supported version.
+This updates the dependency to a supported v5 release.
 
 ### Whitelabel Tenant Errors
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.2.2",
     "vite": "^5.0.8",
-    "vitest": "^1.4.0"
+    "vitest": "^1.4.0",
+    "rimraf": "^5.0.5"
   },
   "peerDependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add rimraf@5 to devDependencies
- document how to install the updated rimraf version

## Testing
- `npm run test` *(fails: vitest not found)*