### PR TITLE
Implement global scroll-to-top on navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import './App.css';
 import { ThemeProvider } from "./components/ThemeProvider";
+import { useScrollToTop } from "./hooks";
 import { WhitelabelProvider } from "./context/WhitelabelContext";
 import { Toaster } from "./components/ui/toaster";
 import { Toaster as SonnerToaster } from "./components/ui/sonner";
@@ -62,6 +63,8 @@ const baseRoutes = [
 ];
 
 const App = () => {
+  // Ensure each navigation starts at the top of the page
+  useScrollToTop();
   return (
     <WhitelabelProvider>
       <ThemeProvider defaultTheme="dark">

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useAuth';
 export * from './useOnboardingStatus';
 export * from './usePageViewTracking';
 export * from './useReactId';
+export * from './useScrollToTop';

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Scrolls to the top of the window whenever the route changes.
+ */
+export function useScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+}


### PR DESCRIPTION
## Summary
- add `useScrollToTop` hook
- export the new hook
- invoke `useScrollToTop` in `App` to scroll to top of the page on route change

## Testing
- `npm test` *(fails: vitest not found)*