### PR TITLE
Fix unauthenticated favorite toggle

### DIFF
--- a/src/components/profile/talent-card/TalentCardSaveButton.tsx
+++ b/src/components/profile/talent-card/TalentCardSaveButton.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
+import { useNavigate } from "react-router-dom";
 
 interface TalentCardSaveButtonProps {
   profileId: string;
@@ -12,26 +13,28 @@ interface TalentCardSaveButtonProps {
   isAuthenticated: boolean;
 }
 
-export function TalentCardSaveButton({ 
-  profileId, 
+export function TalentCardSaveButton({
+  profileId,
   profileName,
-  isSaved, 
+  isSaved,
   onToggleSave,
-  isAuthenticated 
+  isAuthenticated
 }: TalentCardSaveButtonProps) {
   const { toast } = useToast();
+  const navigate = useNavigate();
   const [localIsSaved, setLocalIsSaved] = React.useState(isSaved);
   
   // Handle save toggle
   const handleSaveToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
-    
+
     if (!isAuthenticated) {
       toast({
         title: "Authentication required",
         description: "Please log in to save talents to your favorites",
         variant: "destructive"
       });
+      navigate('/login');
       return;
     }
     

--- a/src/components/talent/TalentCard.tsx
+++ b/src/components/talent/TalentCard.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Star, MapPin, Clock, ArrowRight, CheckCircle2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { useToast } from "@/hooks/use-toast";
 import { TalentProfile } from "@/types/talent";
 
 export interface TalentCardProps {
@@ -23,6 +24,7 @@ export function TalentCard({
   isAuthenticated
 }: TalentCardProps) {
   const navigate = useNavigate();
+  const { toast } = useToast();
   
   const handleViewProfile = () => {
     // Navigate directly to the talent profile
@@ -45,6 +47,16 @@ export function TalentCard({
   const handleToggleSave = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!isAuthenticated) {
+      toast({
+        title: "Authentication required",
+        description: "Please log in to save talents to your favorites",
+        variant: "destructive"
+      });
+      navigate('/login');
+      return;
+    }
+
     if (onToggleSave) {
       onToggleSave(talent.id, !isSaved);
     }


### PR DESCRIPTION
## Summary
- prevent toggling favorites without authentication by showing a toast and redirecting to login
- apply same logic to talent card save button

## Testing
- `npm test` *(fails: vitest not found)*