### PR TITLE
Fix community category page icon

### DIFF
--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -49,6 +49,7 @@ const iconAliases: Record<string, keyof typeof LucideIcons> = {
   ChevronRight: 'ChevronRight',
   MoreHorizontal: 'MoreHorizontal',
   MoreVertical: 'MoreVertical',
+  Search: 'Search',
   
   // Content
   Quote: 'Quote',


### PR DESCRIPTION
## Summary
- add missing `Search` icon export so community category page renders correctly

## Testing
- `npm test` *(fails: vitest not found)*