### PR TITLE
Persist user preference filters

### DIFF
--- a/src/components/CategoryListingPage.tsx
+++ b/src/components/CategoryListingPage.tsx
@@ -53,9 +53,21 @@ export function CategoryListingPage({
   ]
 }: CategoryListingPageProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedSort, setSelectedSort] = useState(sortOptions[0].value);
-  const [selectedFilter, setSelectedFilter] = useState(filterOptions[0].value);
+  const [selectedSort, setSelectedSort] = useState(
+    () => localStorage.getItem('category_selected_sort') || sortOptions[0].value
+  );
+  const [selectedFilter, setSelectedFilter] = useState(
+    () => localStorage.getItem('category_selected_filter') || filterOptions[0].value
+  );
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem('category_selected_sort', selectedSort);
+  }, [selectedSort]);
+
+  useEffect(() => {
+    localStorage.setItem('category_selected_filter', selectedFilter);
+  }, [selectedFilter]);
 
   useEffect(() => {
     setIsLoading(true);

--- a/src/components/transactions/TransactionHistory.tsx
+++ b/src/components/transactions/TransactionHistory.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
@@ -35,7 +35,13 @@ interface Transaction {
 export function TransactionHistory() {
   const { user } = useAuth();
   const { toast } = useToast();
-  const [filter, setFilter] = useState<'all' | 'pending' | 'completed' | 'escrow'>('all');
+  const [filter, setFilter] = useState<'all' | 'pending' | 'completed' | 'escrow'>(
+    () => (localStorage.getItem('transaction_filter') as any) || 'all'
+  );
+
+  useEffect(() => {
+    localStorage.setItem('transaction_filter', filter);
+  }, [filter]);
   
   const { data: transactions, isLoading, error, refetch } = useQuery({
     queryKey: ['transactions', user?.id, filter],

--- a/src/context/notifications/useNotificationOperations.ts
+++ b/src/context/notifications/useNotificationOperations.ts
@@ -1,11 +1,17 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { Notification, FilterType, NotificationContextType } from './types';
 
 export const useNotificationOperations = (userId?: string): NotificationContextType => {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(false);
-  const [filter, setFilter] = useState<FilterType>('all');
+  const [filter, setFilter] = useState<FilterType>(
+    () => (localStorage.getItem('notification_filter') as FilterType) || 'all'
+  );
+
+  useEffect(() => {
+    localStorage.setItem('notification_filter', filter);
+  }, [filter]);
 
   const fetchNotifications = useCallback(async () => {
     if (!userId) return;


### PR DESCRIPTION
## Summary
- save notification filter to localStorage
- persist transaction history filter
- persist listing page sort and filter

## Testing
- `npm run test` *(fails: vitest not found)*