### PR TITLE
Update auth guards for favorites and post creation

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { useTenantAdminStatus } from '@/hooks/useWhitelabelTenant';
 import { useWhitelabel } from '@/context/WhitelabelContext';
@@ -21,6 +21,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   const { user, isLoading } = useAuth();
   const { tenant } = useWhitelabel();
   const { isAdmin: isTenantAdmin, isLoading: isCheckingTenantAdmin } = useTenantAdminStatus(tenant?.id);
+  const location = useLocation();
   
   const isCheckingPermissions = isLoading || isCheckingTenantAdmin;
 
@@ -33,7 +34,8 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 
   // Redirect to login if not authenticated
   if (!user) {
-    return <Navigate to="/login" />;
+    const next = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/login?next=${next}`} />;
   }
 
   // Check for admin access if required

--- a/src/components/community/CreatePostButton.tsx
+++ b/src/components/community/CreatePostButton.tsx
@@ -11,7 +11,7 @@ interface CreatePostButtonProps {
 /**
  * Renders a button that navigates to the create post page.
  * If the user is not authenticated, they are redirected to the
- * login page with a return path so they can come back after logging in.
+ * login page with a "next" parameter so they can come back after logging in.
  */
 export function CreatePostButton({ categoryId, className }: CreatePostButtonProps) {
   const { user } = useAuth();
@@ -25,7 +25,7 @@ export function CreatePostButton({ categoryId, className }: CreatePostButtonProp
     if (user) {
       navigate(target);
     } else {
-      navigate("/login", { state: { returnTo: target } });
+      navigate(`/login?next=${encodeURIComponent(target)}`);
     }
   };
 

--- a/src/components/profile/talent-card/TalentCardSaveButton.tsx
+++ b/src/components/profile/talent-card/TalentCardSaveButton.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 interface TalentCardSaveButtonProps {
   profileId: string;
@@ -22,6 +22,7 @@ export function TalentCardSaveButton({
 }: TalentCardSaveButtonProps) {
   const { toast } = useToast();
   const navigate = useNavigate();
+  const location = useLocation();
   const [localIsSaved, setLocalIsSaved] = React.useState(isSaved);
   
   // Handle save toggle
@@ -34,7 +35,8 @@ export function TalentCardSaveButton({
         description: "Please log in to save talents to your favorites",
         variant: "destructive"
       });
-      navigate('/login');
+      const next = encodeURIComponent(location.pathname + location.search);
+      navigate(`/login?next=${next}`);
       return;
     }
     

--- a/src/components/talent/TalentCard.tsx
+++ b/src/components/talent/TalentCard.tsx
@@ -2,7 +2,7 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Star, MapPin, Clock, ArrowRight, CheckCircle2 } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
 import { TalentProfile } from "@/types/talent";
 
@@ -24,6 +24,7 @@ export function TalentCard({
   isAuthenticated
 }: TalentCardProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { toast } = useToast();
   
   const handleViewProfile = () => {
@@ -53,7 +54,8 @@ export function TalentCard({
         description: "Please log in to save talents to your favorites",
         variant: "destructive"
       });
-      navigate('/login');
+      const next = encodeURIComponent(location.pathname + location.search);
+      navigate(`/login?next=${next}`);
       return;
     }
 

--- a/src/hooks/talent/useSavedTalents.ts
+++ b/src/hooks/talent/useSavedTalents.ts
@@ -5,12 +5,15 @@ import { TalentProfile } from "@/types/talent";
 import { toast } from "@/hooks/use-toast";
 import { showApiError } from "@/utils/apiErrorHandler";
 import { useAuthStatus } from "@/hooks/talent";
+import { useNavigate, useLocation } from "react-router-dom";
 
 export function useSavedTalents() {
   const { isAuthenticated, userDetails } = useAuthStatus();
   const [savedTalents, setSavedTalents] = useState<TalentProfile[]>([]);
   const [savedTalentIds, setSavedTalentIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
+  const location = useLocation();
 
   // Fetch saved talents
   useEffect(() => {
@@ -68,6 +71,8 @@ export function useSavedTalents() {
         description: "Please log in to save talents to your favorites",
         variant: "destructive"
       });
+      const next = encodeURIComponent(location.pathname + location.search);
+      navigate(`/login?next=${next}`);
       return;
     }
     


### PR DESCRIPTION
## Summary
- use current path for ProtectedRoute login redirects
- pass target to login in CreatePostButton
- preserve attempted path when saving favorites
- redirect to login when toggling favorites via hook

## Testing
- `npm test` *(fails: vitest not found)*