### PR TITLE
Add register API and tests

### DIFF
--- a/pages/api/auth/register.ts
+++ b/pages/api/auth/register.ts
@@ -1,0 +1,59 @@
+import { createClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+
+// Generic request/response types so this file can run in Node or Next.js
+type Req = { method?: string; body?: any };
+interface JsonRes {
+  statusCode?: number;
+  setHeader: (name: string, value: string) => void;
+  end: (data?: any) => void;
+  status: (code: number) => JsonRes;
+  json: (data: any) => void;
+}
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY || '';
+const supabase = createClient(supabaseUrl, serviceKey);
+
+const schema = z.object({
+  name: z.string().min(2, 'Name must be at least 2 characters'),
+  email: z.string().email('Invalid email address'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+export default async function handler(req: Req, res: JsonRes) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  const result = schema.safeParse(req.body);
+  if (!result.success) {
+    const message = result.error.issues[0]?.message || 'Invalid input';
+    res.status(400).json({ error: message });
+    return;
+  }
+
+  const { name, email, password } = result.data;
+  try {
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { display_name: name } },
+    });
+
+    if (error || !data.user) {
+      const status = error?.status || (error?.message?.includes('already registered') ? 409 : 400);
+      res.status(status).json({ error: error?.message || 'Registration failed' });
+      return;
+    }
+
+    const token = data.session?.access_token;
+    if (token) {
+      res.setHeader('Set-Cookie', `token=${token}; HttpOnly; Path=/`);
+    }
+    res.status(201).json({ user: data.user, token });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message || 'Registration failed' });
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,16 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+}

--- a/tests/RegisterApi.test.ts
+++ b/tests/RegisterApi.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler from '@/pages/api/auth/register';
+
+const signUpMock = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    auth: { signUp: signUpMock },
+  })),
+}));
+
+function mockReq(body: any) {
+  return { method: 'POST', body } as any;
+}
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.setHeader = vi.fn();
+  res.end = vi.fn();
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('register API', () => {
+  it('returns 201 on success', async () => {
+    signUpMock.mockResolvedValue({
+      data: { user: { id: '1' }, session: { access_token: 'tok' } },
+      error: null,
+    });
+    const req = mockReq({ name: 'John', email: 'a@b.c', password: 'Password123' });
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ user: { id: '1' }, token: 'tok' });
+  });
+
+  it('returns 409 for duplicate email', async () => {
+    signUpMock.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'User already registered', status: 400 },
+    });
+    const req = mockReq({ name: 'John', email: 'a@b.c', password: 'Password123' });
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({ error: 'User already registered' });
+  });
+});

--- a/tests/Signup.test.tsx
+++ b/tests/Signup.test.tsx
@@ -6,7 +6,7 @@ import * as authHook from '@/hooks/useAuth';
 import * as toastHook from '@/hooks/use-toast';
 import * as router from 'react-router-dom';
 
-function setup(success = true, errorMsg?: string) {
+function setup(success = true, errorMsg?: string, status = success ? 201 : 400) {
   const navigateMock = vi.fn();
   vi.spyOn(router, 'useNavigate').mockReturnValue(navigateMock);
   vi.spyOn(authHook, 'useAuth').mockReturnValue({
@@ -17,7 +17,7 @@ function setup(success = true, errorMsg?: string) {
     user: null,
   } as any);
   const fetchSpy = vi.fn().mockResolvedValue({
-    status: success ? 201 : 400,
+    status,
     json: () => Promise.resolve(success ? { token: 'jwt' } : { error: errorMsg }),
   } as Response);
   vi.stubGlobal('fetch', fetchSpy);
@@ -63,5 +63,17 @@ describe('Signup form', () => {
     fireEvent.submit(screen.getByRole('button', { name: /create account/i }));
     expect(fetchSpy).toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith('Bad');
+  });
+
+  it('handles duplicate email error', async () => {
+    const { fetchSpy, errorSpy } = setup(false, 'Email already exists', 409);
+    fireEvent.input(screen.getByLabelText(/full name/i), { target: { value: 'John Doe' } });
+    fireEvent.input(screen.getByLabelText(/email address/i), { target: { value: 'john@example.com' } });
+    fireEvent.input(screen.getByLabelText(/^password$/i), { target: { value: 'Password123' } });
+    fireEvent.input(screen.getByLabelText(/confirm password/i), { target: { value: 'Password123' } });
+    fireEvent.click(screen.getByLabelText(/i agree/i));
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }));
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith('Email already exists');
   });
 });


### PR DESCRIPTION
## Summary
- implement `/api/auth/register` with Supabase signup and validation
- add Prisma schema with unique email
- extend signup tests for duplicate email handling
- add tests for the register API route

## Testing
- `npm run test` *(fails: vitest not found)*