### PR TITLE
Add subscription feedback to footer form

### DIFF
--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -1,0 +1,27 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.setHeader('Allow', 'POST');
+    res.end('Method Not Allowed');
+    return;
+  }
+
+  try {
+    const { email } = req.body || {};
+    if (!email) {
+      res.statusCode = 400;
+      res.json({ error: 'Email is required' });
+      return;
+    }
+
+    // Placeholder for subscription logic (e.g., store in DB or send to service)
+    console.log('New newsletter subscriber:', email);
+
+    res.statusCode = 200;
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Subscribe API error:', err);
+    res.statusCode = 500;
+    res.json({ error: err.message || 'Subscription failed' });
+  }
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { NewsletterForm } from "@/components/NewsletterForm";
+import { FooterNewsletter } from "@/components/FooterNewsletter";
 import { Twitter, Linkedin, Facebook, Instagram, Github } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -97,7 +97,7 @@ export function Footer() {
             <p className="text-zion-slate-light mb-4">
               Stay updated with the latest news on tech, AI, and marketplace opportunities.
             </p>
-            <NewsletterForm />
+            <FooterNewsletter />
           </div>
         </div>
 

--- a/src/components/FooterNewsletter.jsx
+++ b/src/components/FooterNewsletter.jsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2 } from 'lucide-react';
+
+export function FooterNewsletter() {
+  const [email, setEmail] = useState('');
+  const [honeypot, setHoneypot] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (honeypot) return; // ignore bots
+    setIsSubmitting(true);
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+
+      if (res.ok) {
+        toast.success('Subscribed!');
+        setEmail('');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error || 'Subscription failed');
+      }
+    } catch (err) {
+      toast.error(err.message || 'Subscription failed');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col space-y-3 sm:flex-row sm:space-y-0 sm:space-x-2"
+    >
+      <Input
+        type="email"
+        placeholder="Enter your email"
+        className="flex-grow bg-zion-blue-light text-black border-zion-purple/20 focus:border-zion-purple focus:ring-zion-purple"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      {/* Honeypot field */}
+      <input
+        type="text"
+        value={honeypot}
+        onChange={(e) => setHoneypot(e.target.value)}
+        tabIndex="-1"
+        autoComplete="off"
+        style={{ display: 'none' }}
+      />
+      <Button
+        type="submit"
+        disabled={isSubmitting}
+        className="bg-gradient-to-r from-zion-purple to-zion-purple-dark text-white hover:from-zion-purple-light hover:to-zion-purple"
+      >
+        {isSubmitting ? (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            Subscribing...
+          </>
+        ) : (
+          'Subscribe'
+        )}
+      </Button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple API endpoint at `api/subscribe.js`
- create new `FooterNewsletter` component with spinner, toasts and honeypot
- wire footer to use `FooterNewsletter`

## Testing
- `npm run test` *(fails: jest not found)*