### PR TITLE
Add equipment slug routing

### DIFF
--- a/src/components/ProductListingCard.tsx
+++ b/src/components/ProductListingCard.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ProductListing } from "@/types/listings";
@@ -141,16 +141,17 @@ export function ProductListingCard({
           </div>
           
           <div className="flex gap-2">
-            <Button 
-              size="sm" 
-              onClick={(e) => {
-                e.stopPropagation();
-                navigate(`${detailBasePath}/${listing.id}`);
-              }}
-              className="bg-zion-purple hover:bg-zion-purple-dark text-white"
+            <Link
+              to={`${detailBasePath}/${listing.id}`}
+              onClick={(e) => e.stopPropagation()}
             >
-              Buy Now
-            </Button>
+              <Button
+                size="sm"
+                className="bg-zion-purple hover:bg-zion-purple-dark text-white"
+              >
+                Buy Now
+              </Button>
+            </Link>
             
             {onRequestQuote && (
               <Button 

--- a/src/pages/EquipmentDetail.tsx
+++ b/src/pages/EquipmentDetail.tsx
@@ -39,6 +39,28 @@ interface EquipmentDetails {
 
 // Sample data - in a real app this would come from an API
 const SAMPLE_EQUIPMENT: { [key: string]: EquipmentDetails } = {
+  "2u-rack-mount-server": {
+    id: "2u-rack-mount-server",
+    name: "2U Rack Mount Server",
+    description: "High‑density server optimized for virtualization and private cloud deployments.",
+    brand: "DataCore",
+    category: "Servers",
+    images: ["/images/equipment-placeholder.svg"],
+    price: 4200,
+    currency: "$",
+    rating: 4.8,
+    reviewCount: 23,
+    inStock: true,
+    expectedShipping: "3-5 business days",
+    specifications: [
+      { name: "CPU", value: "Dual Xeon" },
+      { name: "Memory", value: "64GB RAM" },
+      { name: "Power", value: "Dual PSU" },
+    ],
+    features: ["Hot-swappable drives", "Remote management"],
+    warranty: "1 year manufacturer warranty",
+    returnPolicy: "30-day return policy",
+  },
   "pro-camera-x1000": {
     id: "pro-camera-x1000",
     name: "Pro Camera X1000",
@@ -129,7 +151,7 @@ const SAMPLE_EQUIPMENT: { [key: string]: EquipmentDetails } = {
 };
 
 export default function EquipmentDetail() {
-  const { equipmentId } = useParams() as { equipmentId?: string };
+  const { id } = useParams() as { id?: string };
   const navigate = useNavigate();
   const { isAuthenticated } = useAuth();
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
@@ -137,7 +159,7 @@ export default function EquipmentDetail() {
   const [isAdding, setIsAdding] = useState(false);
   
   // In a real app, this would fetch from an API
-  const equipment = equipmentId ? SAMPLE_EQUIPMENT[equipmentId] : undefined;
+  const equipment = id ? SAMPLE_EQUIPMENT[id] : undefined;
   
   if (!equipment) {
     return (
@@ -171,7 +193,7 @@ export default function EquipmentDetail() {
 
   const handleBuyNow = async () => {
     if (!isAuthenticated) {
-      navigate(`/login?next=/equipment/${equipmentId}`);
+      navigate(`/login?next=/equipment/${id}`);
       return;
     }
 
@@ -180,7 +202,7 @@ export default function EquipmentDetail() {
       const response = await fetch('/api/checkout_sessions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ productId: equipmentId }),
+        body: JSON.stringify({ productId: id }),
       });
       const { sessionId } = await response.json();
       const stripe = await getStripe();

--- a/src/pages/EquipmentPage.tsx
+++ b/src/pages/EquipmentPage.tsx
@@ -6,7 +6,7 @@ import { generateRandomEquipment } from "@/utils/generateRandomEquipment";
 // Sample datacenter equipment listings
 const EQUIPMENT_LISTINGS: ProductListing[] = [
   {
-    id: "rack-server-2u",
+    id: "2u-rack-mount-server",
     title: "2U Rack Mount Server",
     description:
       "High‑density server optimized for virtualization and private cloud deployments.",

--- a/tests/EquipmentDetail.test.tsx
+++ b/tests/EquipmentDetail.test.tsx
@@ -10,7 +10,7 @@ jest.mock('react-router-dom', () => ({
 
 describe('EquipmentDetail page', () => {
   it('displays equipment info', () => {
-    (router.useParams as jest.Mock).mockReturnValue({ equipmentId: 'pro-camera-x1000' });
+    (router.useParams as jest.Mock).mockReturnValue({ id: 'pro-camera-x1000' });
 
     const { asFragment, getByText } = render(<EquipmentDetail />);
     expect(getByText(/Pro Camera X1000/i)).toBeInTheDocument();

--- a/tests/EquipmentRouting.test.tsx
+++ b/tests/EquipmentRouting.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import EquipmentDetail from '@/pages/EquipmentDetail';
+
+it('renders equipment detail from slug', async () => {
+  render(
+    <MemoryRouter initialEntries={['/equipment/2u-rack-mount-server']}>
+      <Routes>
+        <Route path='/equipment/:id' element={<EquipmentDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+  expect(await screen.findByText(/2U Rack Mount Server/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- update ProductListingCard Buy Now button to be a Link
- expose `2u-rack-mount-server` listing and fetch equipment by slug
- adjust EquipmentDetail route param usage
- test rendering equipment via slugged route

## Testing
- `npm run test` *(fails: jest not found)*