### PR TITLE
Implement global view mode context

### DIFF
--- a/src/context/ViewModeContext.tsx
+++ b/src/context/ViewModeContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type ViewMode = 'grid' | 'list';
+
+interface ViewModeContextType {
+  viewMode: ViewMode;
+  setViewMode: (mode: ViewMode) => void;
+}
+
+const ViewModeContext = createContext<ViewModeContextType>({
+  viewMode: 'grid',
+  setViewMode: () => {},
+});
+
+export const useViewMode = (): ViewModeContextType => useContext(ViewModeContext);
+
+export function ViewModeProvider({ children }: { children: React.ReactNode }) {
+  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+
+  return (
+    <ViewModeContext.Provider value={{ viewMode, setViewMode }}>
+      {children}
+    </ViewModeContext.Provider>
+  );
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -6,3 +6,4 @@ export {
   RequestQuoteWizardProvider,
   useRequestQuoteWizard
 } from './RequestQuoteWizard';
+export { ViewModeProvider, useViewMode } from './ViewModeContext';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,6 +21,7 @@ import { NotificationProvider } from './context';
 
 // Import analytics provider
 import { AnalyticsProvider } from './context/AnalyticsContext';
+import { ViewModeProvider } from './context/ViewModeContext';
 
 // Initialize a React Query client with global error handling
 const queryClient = new QueryClient({
@@ -45,9 +46,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
               <NotificationProvider>
                 <AnalyticsProvider>
                   <LanguageProvider authState={{ isAuthenticated: false, user: null }}>
-                    <AppLayout>
-                      <App />
-                    </AppLayout>
+                    <ViewModeProvider>
+                      <AppLayout>
+                        <App />
+                      </AppLayout>
+                    </ViewModeProvider>
                     <LanguageDetectionPopup />
                   </LanguageProvider>
                 </AnalyticsProvider>

--- a/src/pages/Marketplace.module.css
+++ b/src/pages/Marketplace.module.css
@@ -1,0 +1,8 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+
+.list {
+  display: block;
+}

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -13,6 +13,8 @@ import { generateRandomListing } from "@/utils/generateRandomListing";
 import { toast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router-dom";
 import { SearchSuggestion } from "@/types/search";
+import styles from './Marketplace.module.css';
+import { useViewMode } from '@/context/ViewModeContext';
 
 interface ProductContainerProps {
   listings: ProductListing[];
@@ -21,7 +23,7 @@ interface ProductContainerProps {
 
 function ProductGrid({ listings, onRequestQuote }: ProductContainerProps) {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 product-grid">
+    <div className={`${styles.grid} gap-6 product-grid`}>
       {listings.map(listing => (
         <ProductListingCard
           key={listing.id}
@@ -36,7 +38,7 @@ function ProductGrid({ listings, onRequestQuote }: ProductContainerProps) {
 
 function ProductList({ listings, onRequestQuote }: ProductContainerProps) {
   return (
-    <div className="flex flex-col gap-4 product-list">
+    <div className={`${styles.list} gap-4 product-list`}>
       {listings.map(listing => (
         <ProductListingCard
           key={listing.id}
@@ -58,7 +60,7 @@ export default function Marketplace() {
   const [selectedRating, setSelectedRating] = useState<number | null>(null);
   const [listings, setListings] = useState(MARKETPLACE_LISTINGS);
   const [isLoading, setIsLoading] = useState(false);
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  const { viewMode, setViewMode } = useViewMode();
 
   // Automatically append a new listing every 2 minutes
   useEffect(() => {

--- a/src/types/external-modules.d.ts
+++ b/src/types/external-modules.d.ts
@@ -9,6 +9,10 @@ declare module "@radix-ui/react-navigation-menu";
 declare module "react-resizable-panels";
 declare module "@radix-ui/react-toggle-group";
 declare module "@radix-ui/react-toggle";
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}
 
 declare module '@tanstack/react-query';
 declare module 'react-day-picker' {

--- a/tests/ViewModeContext.test.tsx
+++ b/tests/ViewModeContext.test.tsx
@@ -1,0 +1,25 @@
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { ViewModeProvider, useViewMode } from '@/context/ViewModeContext';
+jest.mock('@/pages/Marketplace.module.css', () => ({ grid: 'grid', list: 'list' }));
+import styles from '@/pages/Marketplace.module.css';
+
+function TestComponent() {
+  const { viewMode, setViewMode } = useViewMode();
+  return (
+    <div>
+      <button aria-label="List view" onClick={() => setViewMode('list')} />
+      <div data-testid="container" className={viewMode === 'grid' ? styles.grid : styles.list} />
+    </div>
+  );
+}
+
+test('toggle state updates and class applied', () => {
+  const { getByLabelText, getByTestId } = render(
+    <ViewModeProvider>
+      <TestComponent />
+    </ViewModeProvider>
+  );
+  fireEvent.click(getByLabelText('List view'));
+  expect(getByTestId('container').className).toContain(styles.list);
+});


### PR DESCRIPTION
## Summary
- store view mode in new context
- provide ViewModeProvider in main app tree
- style marketplace grid/list view with CSS module
- update marketplace page to use context
- add unit test for view mode toggle

## Testing
- `npm run test` *(fails: jest not found)*