### PR TITLE
Fix CSP eval usage

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,12 @@ export default defineConfig({
     },
   ],
   build: {
+    sourcemap: false,
+    minify: 'esbuild',
     rollupOptions: {
+      output: {
+        inlineDynamicImports: false,
+      },
       external: ['react-markdown'],
     },
   },


### PR DESCRIPTION
## Summary
- ensure no eval-based source maps in Vite build

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*