### PR TITLE
Fix service worker offline handler

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -61,10 +61,15 @@ self.addEventListener('fetch', event => {
   }
   event.respondWith(
     caches.match(event.request).then(response => {
-      return (
-        response ||
-        fetch(event.request).catch(() => caches.match('/offline.html'))
-      );
+      if (response) {
+        return response;
+      }
+      return fetch(event.request).catch(() => {
+        const accepts = event.request.headers.get('accept') || '';
+        if (event.request.mode === 'navigate' || accepts.includes('text/html')) {
+          return caches.match('/offline.html');
+        }
+      });
     })
   );
 });


### PR DESCRIPTION
## Summary
- fix caching logic in `service-worker.js` so offline fallback only applies to navigation requests

## Testing
- `npm run test` *(fails: vitest not found)*