### PR TITLE
Implement grid/list layout toggle

### DIFF
--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -13,8 +13,7 @@ import { generateRandomListing } from "@/utils/generateRandomListing";
 import { toast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router-dom";
 import { SearchSuggestion } from "@/types/search";
-import styles from './Marketplace.module.css';
-import { useViewMode } from '@/context/ViewModeContext';
+
 import {
   Pagination,
   PaginationContent,
@@ -24,40 +23,7 @@ import {
   PaginationPrevious,
 } from '@/components/ui/pagination';
 
-interface ProductContainerProps {
-  listings: ProductListing[];
-  onRequestQuote: (id: string) => void;
-}
 
-function ProductGrid({ listings, onRequestQuote }: ProductContainerProps) {
-  return (
-    <div className={`${styles.grid} gap-6 product-grid`}>
-      {listings.map(listing => (
-        <ProductListingCard
-          key={listing.id}
-          listing={listing}
-          onRequestQuote={onRequestQuote}
-          view="grid"
-        />
-      ))}
-    </div>
-  );
-}
-
-function ProductList({ listings, onRequestQuote }: ProductContainerProps) {
-  return (
-    <div className={`${styles.list} gap-4 product-list`}>
-      {listings.map(listing => (
-        <ProductListingCard
-          key={listing.id}
-          listing={listing}
-          onRequestQuote={onRequestQuote}
-          view="list"
-        />
-      ))}
-    </div>
-  );
-}
 
 export default function Marketplace() {
   const navigate = useNavigate();
@@ -68,7 +34,7 @@ export default function Marketplace() {
   const [selectedRating, setSelectedRating] = useState<number | null>(null);
   const [listings, setListings] = useState(MARKETPLACE_LISTINGS);
   const [isLoading, setIsLoading] = useState(false);
-  const { viewMode, setViewMode } = useViewMode();
+  const [view, setView] = useState<'grid' | 'list'>('grid');
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
 
@@ -205,26 +171,18 @@ export default function Marketplace() {
               />
             </div>
             <div className="flex gap-2">
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => setViewMode('grid')}
+              <Grid3X3
+                onClick={() => setView('grid')}
                 aria-label="Grid view"
-                aria-pressed={viewMode === 'grid'}
-                className="text-zion-slate-light"
-              >
-                <Grid3X3 className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => setViewMode('list')}
+                className={`h-4 w-4 cursor-pointer text-zion-slate-light ${view === 'grid' ? 'text-green-400' : ''}`}
+                data-testid="grid-icon"
+              />
+              <ListFilter
+                onClick={() => setView('list')}
                 aria-label="List view"
-                aria-pressed={viewMode === 'list'}
-                className="text-zion-slate-light"
-              >
-                <ListFilter className="h-4 w-4" />
-              </Button>
+                className={`h-4 w-4 cursor-pointer text-zion-slate-light ${view === 'list' ? 'text-green-400' : ''}`}
+                data-testid="list-icon"
+              />
             </div>
           </div>
         </div>
@@ -275,11 +233,19 @@ export default function Marketplace() {
                 <Loader2 className="h-8 w-8 animate-spin text-zion-purple" />
               </div>
             ) : filteredListings.length > 0 ? (
-              viewMode === 'grid' ? (
-                <ProductGrid listings={paginatedListings} onRequestQuote={handleRequestQuote} />
-              ) : (
-                <ProductList listings={paginatedListings} onRequestQuote={handleRequestQuote} />
-              )
+              <div
+                className={view === 'grid' ? 'grid grid-cols-3 gap-6' : 'flex flex-col gap-4'}
+                data-testid="product-container"
+              >
+                {paginatedListings.map(listing => (
+                  <ProductListingCard
+                    key={listing.id}
+                    listing={listing}
+                    onRequestQuote={handleRequestQuote}
+                    view={view}
+                  />
+                ))}
+              </div>
             ) : (
               <div className="col-span-2 text-center py-16 bg-zion-blue-dark border border-zion-blue-light rounded-lg">
                 <h2 className="text-2xl font-bold text-white mb-4">No Results Found</h2>

--- a/tests/MarketplaceViewToggle.test.tsx
+++ b/tests/MarketplaceViewToggle.test.tsx
@@ -1,0 +1,54 @@
+import { render, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Marketplace from '@/pages/Marketplace';
+
+jest.mock('@/components/search/EnhancedSearchInput', () => ({
+  EnhancedSearchInput: () => <div />,
+}));
+
+jest.mock('@/components/search/FilterSidebar', () => ({
+  FilterSidebar: () => <div />,
+}));
+
+jest.mock('@/components/search/ActiveFiltersBar', () => ({
+  ActiveFiltersBar: () => <div />,
+}));
+
+jest.mock('@/components/ProductListingCard', () => ({
+  ProductListingCard: () => <div />,
+}));
+
+jest.mock('@/components/ui/pagination', () => ({
+  Pagination: ({ children }: any) => <div>{children}</div>,
+  PaginationContent: ({ children }: any) => <div>{children}</div>,
+  PaginationItem: ({ children }: any) => <div>{children}</div>,
+  PaginationLink: ({ children }: any) => <div>{children}</div>,
+  PaginationNext: () => <div />,
+  PaginationPrevious: () => <div />,
+}));
+
+jest.mock('@/utils/generateRandomListing', () => ({
+  generateRandomListing: jest.fn(),
+}));
+
+test('toggling view updates container class', () => {
+  jest.useFakeTimers();
+  const { getByTestId } = render(
+    <MemoryRouter>
+      <Marketplace />
+    </MemoryRouter>
+  );
+  act(() => {
+    jest.runAllTimers();
+  });
+
+  const gridIcon = getByTestId('grid-icon');
+  const listIcon = getByTestId('list-icon');
+  const container = getByTestId('product-container');
+
+  expect(container.className).toContain('grid');
+  fireEvent.click(listIcon);
+  expect(container.className).toContain('flex-col');
+  fireEvent.click(gridIcon);
+  expect(container.className).toContain('grid-cols-3');
+});


### PR DESCRIPTION
## Summary
- add view state and dynamic product layout
- implement toggle icons
- test layout switch behavior

## Testing
- `npm run test` *(fails: vitest not found)*