### PR TITLE
Fix sync automations

### DIFF
--- a/netlify/functions/functions-manifest.json
+++ b/netlify/functions/functions-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-08-11T19:25:12.557Z",
+  "generatedAt": "2025-08-11T20:36:18.729Z",
   "functions": [
     "ai-changelog-runner",
     "auto-scheduler",

--- a/netlify/functions/trigger-all-and-commit.js
+++ b/netlify/functions/trigger-all-and-commit.js
@@ -1,6 +1,6 @@
 exports.handler = async function(event, context) {
   const baseUrl = (process.env.SITE_URL || process.env.URL || process.env.DEPLOY_PRIME_URL || '').replace(/\/$/, '');
-  const buildHook = process.env.NETLIFY_BUILD_HOOK_URL || '';
+  const buildHook = process.env.NETLIFY_BUILD_HOOK_URL || process.env.BUILD_HOOK_URL || '';
   const githubToken = process.env.GITHUB_TOKEN || '';
   const githubRepo = process.env.GITHUB_REPO || 'Zion-Holdings/zion.app';
   const githubBranch = process.env.GIT_BRANCH || 'main';

--- a/scripts/trigger-netlify-automations.cjs
+++ b/scripts/trigger-netlify-automations.cjs
@@ -179,13 +179,12 @@ function gitCommitAndPush(filesToAdd) {
 
   const files = writeTriggerArtifacts(results, functionNames);
 
-  if (!isDryRun) {
-    try {
-      gitCommitAndPush(files);
-    } catch (err) {
-      console.error(err);
-      process.exitCode = 1;
-    }
+  // Always commit the stamp/logs even in dry-run so scheduled workflows can sync
+  try {
+    gitCommitAndPush(files);
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
   }
 
   log('Done.');


### PR DESCRIPTION
Fix sync automations by ensuring scheduled workflows always commit and Netlify functions accept the correct build hook URL.

The GitHub scheduled trigger was not committing a stamp in dry-run mode (when `NETLIFY_BASE_URL` was unset), which prevented the sync chain from proceeding. Additionally, the Netlify function was not correctly picking up the build hook URL from the workflow's environment variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c684d06-e305-4eed-8e15-28fc4ecd9b43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c684d06-e305-4eed-8e15-28fc4ecd9b43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

