### PR TITLE
Build failed due to syntax error and missing output directory

### DIFF
--- a/pages/site-health.tsx
+++ b/pages/site-health.tsx
@@ -8,7 +8,7 @@ export default function SiteHealth() {
         <h1 className="text-4xl font-extrabold mb-2">Site Health</h1>
         <p className="text-white/70 mb-6">Automatically detected external images that failed to load.</p>
         <ul className="list-disc pl-6">
-          <li className=\"py-2\">No issues found.</li>
+          <li className="py-2">No issues found.</li>
         </ul>
       </main>
     </div>


### PR DESCRIPTION
Fix syntax error in `pages/site-health.tsx` caused by invalid escaped quotes.

---
<a href="https://cursor.com/background-agent?bcId=bc-d36a13b5-bfe7-46ce-a132-06fea11154d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d36a13b5-bfe7-46ce-a132-06fea11154d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

