### PR TITLE
Fix sidebar visibility issue

### DIFF
--- a/pages/main/front/index.tsx
+++ b/pages/main/front/index.tsx
@@ -331,7 +331,7 @@ export default function MainFrontIndex() {
         </section>
 
         {/* Floating Quick-Nav Dock */}
-        <aside className="fixed left-4 top-1/2 z-30 hidden -translate-y-1/2 lg:block">
+        <aside className="fixed left-4 top-1/2 z-30 -translate-y-1/2 block">
           <nav aria-label="Quick section navigation" className="space-y-2">
             {[
               ['#command-center', 'Command'],


### PR DESCRIPTION
Make the quick-nav sidebar visible on all screen sizes.

The sidebar was previously hidden on small screens (`hidden lg:block`), which prevented it from being seen as per the user's report. This change ensures it is always displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-77e390fe-30dd-4544-969f-6fd5926f65ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77e390fe-30dd-4544-969f-6fd5926f65ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

