### PR TITLE
Migrate pm2 to GitHub actions

### DIFF
--- a/.github/workflows/front-scheduler.yml
+++ b/.github/workflows/front-scheduler.yml
@@ -1,0 +1,66 @@
+name: Front Continuous Scheduler
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: front-scheduler-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure branch up to date
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          git fetch origin
+          git checkout "$BRANCH"
+          git pull --rebase origin "$BRANCH" || true
+
+      - name: Run continuous front runner
+        env:
+          FRONT_SCHEDULER_INTERVAL_MINUTES: '5'
+          FRONT_MAX_INTERVAL_MINUTES: '30'
+          FRONT_RUN_TIMEOUT_MS: '270000'
+          FRONT_JITTER_PCT: '0.15'
+          FRONT_BACKOFF_MULTIPLIER: '1.6'
+          FRONT_HEARTBEAT_MS: '60000'
+        run: npm run front:continuous
+
+      - name: Commit and push any changes
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -e
+          git add -A
+          git commit -m "chore: front CI sync [skip ci]" || true
+          git push origin "$BRANCH" || true

--- a/.github/workflows/guardian-scheduler.yml
+++ b/.github/workflows/guardian-scheduler.yml
@@ -1,0 +1,67 @@
+name: Guardian Scheduler
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: guardian-scheduler-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure branch up to date
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          git fetch origin
+          git checkout "$BRANCH"
+          git pull --rebase origin "$BRANCH" || true
+
+      - name: Run guardian
+        env:
+          # Optional tunables mirroring pm2 env; adjust via workflow vars/secrets if needed
+          GUARDIAN_SCHEDULER_INTERVAL_MINUTES: '10'
+          GUARDIAN_MAX_INTERVAL_MINUTES: '60'
+          GUARDIAN_RUN_TIMEOUT_MS: '540000'
+          GUARDIAN_JITTER_PCT: '0.15'
+          GUARDIAN_BACKOFF_MULTIPLIER: '1.6'
+          GUARDIAN_HEARTBEAT_MS: '60000'
+        run: npm run automation:guardian
+
+      - name: Commit and push any changes
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -e
+          git add -A
+          git commit -m "chore: guardian CI sync [skip ci]" || true
+          git push origin "$BRANCH" || true


### PR DESCRIPTION
Migrate pm2-based schedulers to GitHub Actions to replace server-dependent cron-like tasks with cloud-native workflows.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0e89fd3-fa76-4be1-907d-0989939bef7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0e89fd3-fa76-4be1-907d-0989939bef7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

