### PR TITLE
Changes from background agent bc-48461f9b-0a4a-4201-97e1-9dcf030b601c

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "dev": "NODE_OPTIONS=\"--max-old-space-size=4096 --openssl-legacy-provider\" next dev",
     "build": "NODE_OPTIONS=\"--max-old-space-size=6144 --openssl-legacy-provider\" next build",
     "prebuild": "npm run netlify:manifest",
-    "export": "rm -rf .next out tsconfig.tsbuildinfo && NODE_OPTIONS=\"--max-old-space-size=6144 --openssl-legacy-provider\" next build --no-lint && if [ -f _redirects ]; then cp -f _redirects out/_redirects; fi && if [ -f public/_headers ]; then cp -f _headers out/_headers; elif [ -f _headers ]; then cp -f _headers out/_headers; fi",
+    "export": "rm -rf .next out tsconfig.tsbuildinfo && NODE_OPTIONS=\"--max-old-space-size=6144 --openssl-legacy-provider\" next build --no-lint && if [ -f _redirects ]; then cp -f _redirects out/_redirects; fi && if [ -f public/_headers ]; then cp -f public/_headers out/_headers; elif [ -f _headers ]; then cp -f _headers out/_headers; fi",
     "start": "next start",
     "postbuild": "node automation/footer-injector.cjs || true",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
Fixes Netlify build by correcting the `export` script to properly copy `public/_headers`.

The previous `export` script contained a bug where, if `public/_headers` existed, it would incorrectly attempt to copy `_headers` from the root directory instead, leading to a "cannot stat '_headers'" error and build failure. This change ensures the correct `public/_headers` file is copied to the output directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-48461f9b-0a4a-4201-97e1-9dcf030b601c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-48461f9b-0a4a-4201-97e1-9dcf030b601c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

