### PR TITLE
Fix invalid cron for homepage auto update

### DIFF
--- a/.github/workflows/homepage-auto-update.yml
+++ b/.github/workflows/homepage-auto-update.yml
@@ -3,7 +3,7 @@ name: Homepage Auto Update
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * *  # Every 30 minutes'
+    - cron: '*/30 * * * *'  # Every 30 minutes
 
 permissions:
   contents: write


### PR DESCRIPTION
Correct cron schedule in `homepage-auto-update.yml` to fix workflow failure caused by an invalid expression and ensure it runs every 30 minutes.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e284a20-bc70-44f9-bbfe-263d6eb01080">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e284a20-bc70-44f9-bbfe-263d6eb01080">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

