### PR TITLE
Fix yaml syntax error in workflow

### DIFF
--- a/.github/workflows/agent-agent-1755379777751-3-monitoring-advanced.yml
+++ b/.github/workflows/agent-agent-1755379777751-3-monitoring-advanced.yml
@@ -1,4 +1,4 @@
-name: Agent: agent-1755379777751-3-monitoring-advanced
+name: "Agent: agent-1755379777751-3-monitoring-advanced"
 
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
Quote the `name` field in the workflow file to fix a YAML syntax error caused by an unquoted colon.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d9f4929-0a10-4b1d-aeeb-f8827e98f8c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d9f4929-0a10-4b1d-aeeb-f8827e98f8c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

