### PR TITLE
Fix yaml syntax error in workflow file

### DIFF
--- a/.github/workflows/agent-agent-1755379777746-0-full-stack-advanced.yml
+++ b/.github/workflows/agent-agent-1755379777746-0-full-stack-advanced.yml
@@ -1,4 +1,4 @@
-name: Agent: agent-1755379777746-0-full-stack-advanced
+name: 'Agent: agent-1755379777746-0-full-stack-advanced'
 
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
Quote the workflow `name` field to resolve YAML syntax error caused by a colon.

---
<a href="https://cursor.com/background-agent?bcId=bc-7987b661-e878-4b99-a72b-4488edea58f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7987b661-e878-4b99-a72b-4488edea58f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

