### PR TITLE
Fix homepage auto update cron syntax

### DIFF
--- a/.github/workflows/homepage-auto-update.yml
+++ b/.github/workflows/homepage-auto-update.yml
@@ -3,7 +3,7 @@ name: Homepage Auto Update
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * *  # Every 30 minutes'
+    - cron: '*/30 * * * *'  # Every 30 minutes
 
 permissions:
   contents: write


### PR DESCRIPTION
Fix invalid cron syntax in `homepage-auto-update.yml` to resolve workflow failure.

The `cron` attribute previously contained an inline comment within the string, which is not valid YAML for GitHub Actions, leading to a parsing error. This change moves the comment outside the string and sets the schedule to run every 30 minutes.

---
<a href="https://cursor.com/background-agent?bcId=bc-329cbee9-7db5-4d6e-8733-98abbb2a8925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-329cbee9-7db5-4d6e-8733-98abbb2a8925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

