### PR TITLE
Fix invalid cron attribute in workflow

### DIFF
--- a/.github/workflows/app-automation.yml
+++ b/.github/workflows/app-automation.yml
@@ -3,7 +3,7 @@ name: App Automation
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 1 * * 1  # Every Monday at 1 AM'
+    - cron: '0 1 * * 1' # Every Monday at 1 AM
 
 permissions:
   contents: write

--- a/.github/workflows/app-monitoring.yml
+++ b/.github/workflows/app-monitoring.yml
@@ -3,7 +3,7 @@ name: App Monitoring
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * *  # Every 6 hours'
+    - cron: '0 0 * * *' # Every 6 hours
 
 permissions:
   contents: write

--- a/.github/workflows/automation-cleanup.yml
+++ b/.github/workflows/automation-cleanup.yml
@@ -3,7 +3,7 @@ name: Automation Cleanup
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 2 * * * # Daily at 2 AM'
+    - cron: '0 2 * * *' # Daily at 2 AM
 
 permissions:
   contents: write

--- a/.github/workflows/automation-dashboard.yml
+++ b/.github/workflows/automation-dashboard.yml
@@ -3,7 +3,7 @@ name: Automation Dashboard
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * *  # Every 4 hours'
+    - cron: '0 0 * * *' # Every 4 hours
 
 permissions:
   contents: write

--- a/.github/workflows/autonomous-cloud-automations.yml
+++ b/.github/workflows/autonomous-cloud-automations.yml
@@ -3,7 +3,7 @@ name: Autonomous Cloud Automations
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * * # hourly'
+    - cron: '0 0 * * *' # hourly
 
 permissions:
   contents: write

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -3,7 +3,7 @@ name: Branch Cleanup
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '17 3 * * * # daily at 03:17 UTC'
+    - cron: '17 3 * * *' # daily at 03:17 UTC
 
 permissions:
   contents: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: CodeQL Analysis
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 2 * * 0  # Weekly on Sunday at 2 AM UTC'
+    - cron: '0 2 * * 0' # Weekly on Sunday at 2 AM UTC
 
 permissions:
   contents: write

--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -3,7 +3,7 @@ name: Content Generation
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 2 * * 1  # Every Monday at 2 AM'
+    - cron: '0 2 * * 1' # Every Monday at 2 AM
 
 permissions:
   contents: write

--- a/.github/workflows/exponential-ai-delegation.yml
+++ b/.github/workflows/exponential-ai-delegation.yml
@@ -3,7 +3,7 @@ name: Exponential AI Delegation
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * *  # Every 4 hours'
+    - cron: '0 0 * * *' # Every 4 hours
 
 permissions:
   contents: write

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,7 +3,7 @@ name: Secret scan (Gitleaks)
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 3 * * *  # daily at 03:00 UTC'
+    - cron: '0 3 * * *' # daily at 03:00 UTC
 
 permissions:
   contents: write

--- a/.github/workflows/homepage-auto-update.yml
+++ b/.github/workflows/homepage-auto-update.yml
@@ -3,7 +3,7 @@ name: Homepage Auto Update
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * *  # Every 30 minutes'
+    - cron: '0 0 * * *' # Every 30 minutes
 
 permissions:
   contents: write

--- a/.github/workflows/intelligent-content-generation.yml
+++ b/.github/workflows/intelligent-content-generation.yml
@@ -3,7 +3,7 @@ name: Intelligent Content Generation
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 2 * * *  # Daily at 2 AM'
+    - cron: '0 2 * * *' # Daily at 2 AM
 
 permissions:
   contents: write

--- a/.github/workflows/performance-monitoring.yml
+++ b/.github/workflows/performance-monitoring.yml
@@ -3,7 +3,7 @@ name: Performance Monitoring
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * *  # Every 6 hours'
+    - cron: '0 0 * * *' # Every 6 hours
 
 permissions:
   contents: write

--- a/.github/workflows/yaml-auto-fixer-simple.yml
+++ b/.github/workflows/yaml-auto-fixer-simple.yml
@@ -3,7 +3,7 @@ name: YAML Auto-Fixer (Simple)
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 2 * * *  # Daily at 2 AM'
+    - cron: '0 2 * * *' # Daily at 2 AM
 
 permissions:
   contents: write

--- a/.github/workflows/yaml-auto-fixer.yml
+++ b/.github/workflows/yaml-auto-fixer.yml
@@ -3,7 +3,7 @@ name: YAML Auto-Fixer
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 2 * * *  # Daily at 2 AM'
+    - cron: '0 2 * * *' # Daily at 2 AM
 
 permissions:
   contents: write

--- a/.github/workflows/yaml-validator.yml
+++ b/.github/workflows/yaml-validator.yml
@@ -3,7 +3,7 @@ name: YAML Syntax Validator
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0 * * *  # Daily validation'
+    - cron: '0 0 * * *' # Daily validation
 
 permissions:
   contents: write


### PR DESCRIPTION
Fixes invalid `cron` attribute syntax in GitHub workflow files to resolve parsing errors.

The `cron` attribute in several workflow YAML files contained inline comments within the quoted string (e.g., `'0 2 * * * # Daily at 2 AM'`), which is invalid syntax and caused workflow failures. This PR moves the comments outside the quotes (e.g., `'0 2 * * *' # Daily at 2 AM`) to conform to valid YAML and GitHub Actions syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a175385-cb40-4612-bf4a-e5c66784777d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a175385-cb40-4612-bf4a-e5c66784777d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

