### PR TITLE
Analyze, improve, and deploy application

### DIFF
--- a/data/missing-slugs.json
+++ b/data/missing-slugs.json
@@ -1,17 +1,10 @@
 [
   "ai-autonomous-marketing-platform",
-  "ai-creativity-studio",
-  "ai-education-platform",
-  "ai-financial-intelligence",
-  "ai-sustainability-platform",
   "automated-financial-analytics-platform",
   "entertainment-media-solutions",
   "industry-solutions",
   "intelligent-project-management-suite",
   "leadership",
   "real-estate-technology-solutions",
-  "services/ai-evaluation-orchestrator",
-  "services/it-asset-discovery-agent",
-  "services/managed-postgres-ha",
   "transportation-logistics-solutions"
 ]

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -28,10 +28,10 @@ export default function App({ Component, pageProps }: AppProps) {
 	return (
 		<SEOContext.Provider value={{ renderedRef }}>
 			<Analytics />
-			<DefaultSEO />
 			<div className={inter.className}>
 				<Layout>
 					<Component {...pageProps} />
+					<DefaultSEO />
 				</Layout>
 			</div>
 		</SEOContext.Provider>

--- a/pages/thank-you.tsx
+++ b/pages/thank-you.tsx
@@ -8,7 +8,7 @@ export default function ThankYouPage() {
 
 	return (
 		<>
-			<SEO title={pageTitle} description={pageDescription} canonical="/thank-you" />
+			<SEO title={pageTitle} description={pageDescription} canonical="/thank-you" noIndex nofollow />
 			<section className="relative pt-28 pb-16 md:pt-36 md:pb-24">
 				<div className="container mx-auto px-4 max-w-2xl text-center">
 					<h1 className="text-3xl md:text-5xl font-extrabold tracking-tight gradient-text-cyan-purple">Thank you</h1>


### PR DESCRIPTION
Reorder `DefaultSEO` rendering and add `noindex`/`nofollow` to the thank-you page.

This prevents duplicate meta and JSON-LD tags by ensuring `DefaultSEO` renders after page components, and stops search engines from indexing the `thank-you` page.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0f55081-b866-443b-81ff-42c57b0dd8ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0f55081-b866-443b-81ff-42c57b0dd8ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

