### PR TITLE
Parse netlify config for duplicate plugins

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,6 @@
   publish = ".next"
   functions = "netlify/functions"
 
-[[plugins]]
-  package = "@netlify/plugin-nextjs"
-
 [build.environment]
   NODE_OPTIONS = "--max-old-space-size=6144 --openssl-legacy-provider"
 


### PR DESCRIPTION
Remove duplicate `@netlify/plugin-nextjs` entry to fix Netlify build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-016f96f1-6961-49d7-8254-a5253426725c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-016f96f1-6961-49d7-8254-a5253426725c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

