### PR TITLE
Build with yarn dependency error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 
 [build]
   # Use `yarn install` for deterministic installs, Vite builds to dist/
-  command = "yarn cache clean && yarn install --frozen-lockfile && yarn build"
+  command = "corepack disable && npm i -g yarn@1.22.22 && yarn cache clean && yarn install --frozen-lockfile && yarn build"
   publish = "dist"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "bolt.new.zion.app",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "yarn@1.22.22",
   "scripts": {
     "dev": "NODE_OPTIONS=\"--max-old-space-size=4096 --openssl-legacy-provider\" vite",
     "build": "NODE_OPTIONS=\"--max-old-space-size=6144 --openssl-legacy-provider\" vite build",


### PR DESCRIPTION
## Description
This pull request resolves a Netlify build failure stemming from a `MODULE_NOT_FOUND` error for `yarn-1.22.22.cjs`. The issue occurred because Netlify's Node.js 20 environment, with Corepack enabled, attempted to use a project-local Yarn Berry shim that was not present, while the project intended to use Yarn Classic.

The fix involves:
1.  Removing the `packageManager` field from `package.json` to prevent Corepack from misinterpreting the Yarn version.
2.  Updating the Netlify build command in `netlify.toml` to explicitly disable Corepack and globally install Yarn Classic (v1.22.22) before running `yarn install`. This ensures the build uses the correct Yarn version without expecting a non-existent local shim.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] CI/CD improvements

## Related Issues
Closes #(issue number)
Related to #(issue number)

## Testing
- [x] I have tested this change locally (verified `yarn install` runs without error)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change in a browser environment
- [ ] I have tested this change on different devices/screen sizes

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version number if appropriate
- [ ] I have updated the CHANGELOG.md if appropriate

## Screenshots
If applicable, add screenshots to help explain your changes.

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement
- [ ] Performance regression (please explain)

## Security Considerations
- [x] No security implications
- [ ] Security improvement
- [ ] Security concern (please explain)

## Accessibility
- [x] No accessibility changes
- [ ] Accessibility improvement
- [ ] Accessibility concern (please explain)

## Browser Compatibility
- [ ] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on Safari
- [ ] Tested on Edge
- [ ] Tested on mobile browsers

## Additional Notes
This change ensures that Netlify builds correctly by explicitly managing the Yarn version, resolving the conflict between Corepack's default behavior and the project's intended use of Yarn Classic.

---

**Before submitting, please ensure:**
- [x] The build passes locally (`npm run build`)
- [ ] All tests pass (`npm test`)
- [x] The code follows the project's style guidelines
- [x] You have reviewed your own code
- [x] You have tested the changes thoroughly

---
<a href="https://cursor.com/background-agent?bcId=bc-9ce5bf3c-c295-46cd-9ca3-b3f161505d7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ce5bf3c-c295-46cd-9ca3-b3f161505d7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

