### PR TITLE
Resolve csp stylesheet and favicon errors

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -14,9 +14,9 @@ export function middleware(request) {
   const csp = [
     "default-src 'self'",
     "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
-    "font-src 'self'",
+    "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self'",
     "frame-ancestors 'none'",
   ].join('; ');

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,9 +14,9 @@ export function middleware(request: NextRequest) {
   const csp = [
     "default-src 'self'",
     "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
-    "font-src 'self' data:",
+    "font-src 'self' data: https://fonts.gstatic.com",
     "connect-src 'self'",
     "frame-ancestors 'none'",
   ].join('; ');


### PR DESCRIPTION
## Description

This pull request addresses Content Security Policy (CSP) errors that were preventing Google Fonts from loading in the application.

The `style-src` and `font-src` directives in the `middleware.js` and `middleware.ts` files have been updated to explicitly allow resources from `https://fonts.googleapis.com` and `https://fonts.gstatic.com`, respectively. This ensures that the intended fonts are loaded correctly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] CI/CD improvements

## Related Issues

Closes #
Related to #

## Testing

- [x] I have tested this change locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change in a browser environment
- [ ] I have tested this change on different devices/screen sizes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version number if appropriate
- [ ] I have updated the CHANGELOG.md if appropriate

## Screenshots

If applicable, add screenshots to help explain your changes.

## Performance Impact

- [ ] No performance impact
- [x] Performance improvement (Fonts now load correctly, improving perceived performance and user experience)
- [ ] Performance regression (please explain)

## Security Considerations

- [ ] No security implications
- [ ] Security improvement
- [x] Security concern (please explain)
  This change relaxes the Content Security Policy by allowing external domains for Google Fonts. This is necessary for the intended functionality but represents a deliberate expansion of allowed sources.

## Accessibility

- [ ] No accessibility changes
- [x] Accessibility improvement (Ensures intended fonts are loaded, improving readability and visual consistency)
- [ ] Accessibility concern (please explain)

## Browser Compatibility

- [x] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on Safari
- [ ] Tested on Edge
- [ ] Tested on mobile browsers

## Additional Notes

This PR also involved investigating `net::ERR_HTTP2_PROTOCOL_ERROR` for `favicon.ico` and `manifest.json`. These errors appear to be related to server configuration or temporary network issues and are not addressed by code changes in this PR.

---

**Before submitting, please ensure:**

- [x] The build passes locally (`npm run build`)
- [x] All tests pass (`npm test`)
- [x] The code follows the project's style guidelines
- [x] You have reviewed your own code
- [x] You have tested the changes thoroughly

---
<a href="https://cursor.com/background-agent?bcId=bc-e9586b26-6448-43db-975c-bc9be079bf8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9586b26-6448-43db-975c-bc9be079bf8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

