### PR TITLE
Build project with dependency installation

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
   command_timeout = "30m"
 
 [build.environment]
-  NODE_VERSION = "18"
+  NODE_VERSION = "20"
 
 [[plugins]]
   package = "netlify-plugin-compress"

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.11.9
+python-3.11


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses a Netlify build failure by resolving Python and Node.js version mismatches.

The `runtime.txt` file was updated from `python-3.11.9` to `python-3.11` because the `mise` tool on Netlify could not find the specific patch version, leading to build errors. Using `python-3.11` allows `mise` to correctly install the latest available 3.11.x version.

Additionally, the `netlify.toml` was updated to set `NODE_VERSION = "20"`, aligning with the `package.json` requirement of `">=20.18.1"` and preventing potential Node.js environment conflicts during the build.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [x] I have tested this change locally (verified configuration changes)
- [ ] I have added tests for this change
- [ ] All existing tests pass
- [x] I have tested the build process (local tests confirmed configuration validity, Netlify build expected to pass)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A for config files)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (N/A, configuration fix)
- [x] New and existing unit tests pass locally with my changes (N/A, configuration fix)
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
This PR directly addresses the "Failed during stage 'Install dependencies': dependency_installation script returned non-zero exit code: 1" error observed in Netlify builds, specifically related to `mise` failing to install `python-3.11.9`.

---
<a href="https://cursor.com/background-agent?bcId=bc-29a4fc5b-2efb-469f-949c-fbdbd4a9acaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29a4fc5b-2efb-469f-949c-fbdbd4a9acaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

