### PR TITLE
Install python dependencies with mise

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
 
 [build.environment]
   NODE_VERSION = "20"
-  PYTHON_VERSION = "3.11"
+  PYTHON_VERSION = "3.11.9"
 
 [[plugins]]
   package = "netlify-plugin-compress"


### PR DESCRIPTION
# Pull Request

## Description
Updated `PYTHON_VERSION` in `netlify.toml` from `3.11` to `3.11.9` to resolve Netlify build failures. The previous version `3.11` was not specific enough for `mise`/`python-build`, leading to a "definition not found" error during dependency installation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [ ] I have tested this change locally
- [ ] I have added tests for this change
- [ ] All existing tests pass
- [x] I have tested the build process

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)


## Additional Notes
This change addresses the `mise ERROR python-build: definition not found: python-3.11` error encountered during Netlify builds. `mise` (and `pyenv`) often require a specific patch version for Python installations.

If the build still fails, consider:
- Clearing the Netlify build cache and redeploying.
- Adding a Netlify environment variable: `MISE_SETTINGS__PYTHON__COMPILE` with value `false`.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa26c233-0e0d-427c-a8ba-e06b00c81182">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa26c233-0e0d-427c-a8ba-e06b00c81182">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

