### PR TITLE
Build and install project dependencies

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,10 @@
 
 [build.environment]
   NODE_VERSION = "20"
-  PYTHON_VERSION = "3.11"
+  PYTHON_VERSION = "3.12"
+  # Ensure mise uses precompiled Python and is verbose for debugging
+  MISE_VERBOSE = "1"
+  MISE_PYTHON_COMPILE = "false"
 
 [[plugins]]
   package = "netlify-plugin-compress"

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.11
+python-3.12


### PR DESCRIPTION
# Pull Request

## Description
Fixes Netlify build failures caused by `mise` being unable to install `python-3.11`. This PR updates the Python version to `3.12` in `netlify.toml` and `runtime.txt`, and configures `mise` to use precompiled Python versions to prevent compilation errors.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [ ] I have tested this change locally
- [ ] I have added tests for this change
- [ ] All existing tests pass
- [x] I have tested the build process

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)


## Additional Notes
The previous build failed with `mise ERROR Failed to install tool: python@python-3.11` and `python-build: definition not found: python-3.11`. This change addresses that by ensuring a supported Python version is used and `mise` does not attempt to compile it from source.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ee704eb-8551-4dbe-b4e7-2138655d3484">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ee704eb-8551-4dbe-b4e7-2138655d3484">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

