### PR TITLE
Build failed installing python dependencies

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
 
 [build.environment]
   NODE_VERSION = "20"
-  PYTHON_VERSION = "3.11"
+  PYTHON_VERSION = "3.11.9"
 
 [[plugins]]
   package = "netlify-plugin-compress"

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.11
+python-3.11.9


### PR DESCRIPTION
# Pull Request

## Description
Updates Python version specifications to `3.11.9` in `runtime.txt` and `netlify.toml`. This resolves Netlify build failures where `mise` could not find a definition for `python-3.11`, ensuring it uses a resolvable, precompiled binary.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [ ] I have tested this change locally
- [ ] I have added tests for this change
- [ ] All existing tests pass
- [x] I have tested the build process (Requires Netlify deploy to confirm fix)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
The Netlify build logs indicated `mise` could not find a definition for `python-3.11`, leading to a failed dependency installation. Pinning to `python-3.11.9` provides a concrete version that `mise` can resolve, leveraging precompiled binaries available in the build environment. This should resolve the `python-build: definition not found` error.

---
<a href="https://cursor.com/background-agent?bcId=bc-67a4d235-d86b-49a9-b6cb-c9ad83acc5f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67a4d235-d86b-49a9-b6cb-c9ad83acc5f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

