### PR TITLE
Fix netlify.toml plugin configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,10 +13,7 @@
   CYPRESS_INSTALL_BINARY = "0"
   ELECTRON_SKIP_DOWNLOAD = "1"
 
-## Disable Next.js runtime plugin since we're deploying a static export
-[[plugins]]
-  package = "@netlify/plugin-nextjs"
-  enabled = false
+## Next.js runtime plugin disabled: remove plugin block to avoid invalid keys
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
# Pull Request

## Description
Removes an invalid `[[plugins]]` block from `netlify.toml` that was causing build failures. The `enabled` property is not a valid configuration key for Netlify plugins, and removing the block resolves the configuration parsing error. This effectively disables the `@netlify/plugin-nextjs` plugin, which was the original intent for a static export.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [x] I have tested this change locally
- [ ] I have added tests for this change
- [ ] All existing tests pass
- [ ] I have tested the build process

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
The Netlify build was failing with "Configuration property plugins[1] has unknown properties" due to the `enabled = false` line within the `[[plugins]]` block. Removing the entire block resolves the parsing error and correctly disables the plugin for static exports.

---
<a href="https://cursor.com/background-agent?bcId=bc-01d9674d-fb32-47b8-b3f7-85e8ef948f24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01d9674d-fb32-47b8-b3f7-85e8ef948f24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

