### PR TITLE
Fix netlify.toml plugin configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,10 +15,7 @@
   CYPRESS_INSTALL_BINARY = "0"
   ELECTRON_SKIP_DOWNLOAD = "1"
 
-# Attempt to disable Next.js plugin if installed via file-based config
-[[plugins]]
-  package = "@netlify/plugin-nextjs"
-  pinned_version = "5"
+
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
# Pull Request

## Description
Removes the `[[plugins]]` block for `@netlify/plugin-nextjs` from `netlify.toml`. This resolves a build failure caused by Netlify's configuration parser encountering unknown properties within the plugin definition.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [x] I have tested this change locally
- [ ] I have added tests for this change
- [x] All existing tests pass
- [x] I have tested the build process

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)


## Additional Notes
This change addresses the error: "Configuration property plugins[1] has unknown properties. Valid properties are: - package - pinned_version - inputs". Removing the block allows the build to proceed past the configuration parsing stage.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bec7962-2798-4aba-8034-0479dc6e2978">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bec7962-2798-4aba-8034-0479dc6e2978">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

