### PR TITLE
Build and deploy web application

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,8 @@
   [build.environment]
     NODE_VERSION = "20.18.1"
     SKIP_TYPE_CHECK = "true"
+    # Ensure devDependencies (e.g., Vite) are installed during CI
+    NPM_FLAGS = "--include=dev"
 
 # Trigger: trivial edit to confirm Netlify picks up config and rebuilds
 


### PR DESCRIPTION
# Pull Request

## Description
Fixes a Netlify build failure where the `vite` command was not found. This occurred because `vite` is a devDependency and was not being installed during the production build due to `NODE_ENV=production`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [ ] I have tested this change locally
- [ ] I have added tests for this change
- [ ] All existing tests pass
- [x] I have tested the build process (will be verified by Netlify deploy)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
The Netlify build environment sets `NODE_ENV=production` by default, which prevents `npm ci` from installing `devDependencies`. Since `vite` is a `devDependency` and is used in the `build` script, it was not available, leading to the "vite: not found" error. Adding `NPM_FLAGS = "--include=dev"` to `netlify.toml` ensures that `devDependencies` are installed, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a641571-d8c2-4880-9ff5-3cd926b96190">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a641571-d8c2-4880-9ff5-3cd926b96190">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

