### PR TITLE
Build project with vite and netlify

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,3 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,4 @@
 /*    /index.html   200
 
 # Cache static assets aggressively
-/assets/*  Cache-Control: public, max-age=31536000, immutable
+# Moved to _headers; redirects file does not support header directives


### PR DESCRIPTION
# Pull Request

## Description
Resolves a Netlify build warning by moving the `Cache-Control` header for `/assets/*` from `public/_redirects` to `public/_headers`. The `_redirects` file does not support header directives, causing the "Could not parse redirect line" error.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [x] I have tested this change locally
- [ ] I have added tests for this change
- [ ] All existing tests pass
- [x] I have tested the build process

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
This change addresses the Netlify build warning:
`Warning: some redirects have syntax errors: Could not parse redirect line 4: /assets/* Cache-Control: public, max-age=31536000, immutable The destination path/URL must start with "/", "http:" or "https:"`

---
<a href="https://cursor.com/background-agent?bcId=bc-0863b7ca-a098-46c2-8c6f-328e860545f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0863b7ca-a098-46c2-8c6f-328e860545f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

