### PR TITLE
Fix netlify.toml plugin configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -92,6 +92,4 @@
     X-Permitted-Cross-Domain-Policies = "none"
     Origin-Agent-Cluster = "?1"
 
-[[plugins]]
-  package = "@netlify/plugin-nextjs"
-  enabled = false
+ 


### PR DESCRIPTION
# Pull Request

## Description
Removes an invalid `[[plugins]]` block from `netlify.toml` that was causing Netlify builds to fail due to an unsupported `enabled = false` property. The `@netlify/plugin-nextjs` is already being skipped via `NETLIFY_NEXT_PLUGIN_SKIP`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [x] I have tested this change locally
- [ ] I have added tests for this change
- [x] All existing tests pass
- [x] I have tested the build process

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
The `[[plugins]]` block with `enabled = false` was causing a configuration parsing error during Netlify builds. This block is redundant as the `@netlify/plugin-nextjs` is already being skipped via the `NETLIFY_NEXT_PLUGIN_SKIP` environment variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6a36678-ceb1-4ef3-b984-74f65ba0dae8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6a36678-ceb1-4ef3-b984-74f65ba0dae8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

