### PR TITLE
Fix netlify build and merge to main

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+# SPA fallback for client-side routing
+/*    /index.html   200

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,14 +40,9 @@
         "next": "^14.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-<<<<<<< HEAD
         "react-error-boundary": "^6.0.0",
         "react-hook-form": "^7.47.0",
         "react-router-dom": "^6.30.1",
-=======
-        "react-hook-form": "^7.47.0",
-        "react-router-dom": "^6.17.0",
->>>>>>> origin/cursor/fix-netlify-build-and-merge-to-main-4497
         "react-scripts": "5.0.1",
         "tailwind-merge": "^2.0.0",
         "tailwindcss-animate": "^1.0.7",
@@ -72,10 +67,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-<<<<<<< HEAD
-=======
         "eslint-plugin-react-refresh": "^0.4.20",
->>>>>>> origin/cursor/fix-netlify-build-and-merge-to-main-4497
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8.4.31",
@@ -11087,8 +11079,6 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.4.20",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.20.tgz",
@@ -11099,7 +11089,6 @@
         "eslint": ">=8.40"
       }
     },
->>>>>>> origin/cursor/fix-netlify-build-and-merge-to-main-4497
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -19446,7 +19435,6 @@
         "react": "^18.3.1"
       }
     },
-<<<<<<< HEAD
     "node_modules/react-error-boundary": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
@@ -19459,8 +19447,6 @@
         "react": ">=16.13.1"
       }
     },
-=======
->>>>>>> origin/cursor/fix-netlify-build-and-merge-to-main-4497
     "node_modules/react-error-overlay": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,10 +2,5 @@ export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
-<<<<<<< HEAD
   },
 };
-=======
-  }
-}
->>>>>>> origin/cursor/fix-netlify-build-and-merge-to-main-4497

--- a/yarn.lock
+++ b/yarn.lock
@@ -5820,14 +5820,11 @@ eslint-plugin-react-hooks@^4.3.0, eslint-plugin-react-hooks@^4.6.0:
   resolved "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz"
   integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
 
-<<<<<<< HEAD
-=======
 eslint-plugin-react-refresh@^0.4.20:
   version "0.4.20"
   resolved "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.20.tgz"
   integrity sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==
 
->>>>>>> origin/cursor/fix-netlify-build-and-merge-to-main-4497
 eslint-plugin-react@^7.27.1, eslint-plugin-react@^7.33.2:
   version "7.37.5"
   resolved "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz"
@@ -10279,19 +10276,18 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-error-boundary@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz"
+  integrity sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.11:
   version "6.1.0"
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz"
   integrity sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==
 
-<<<<<<< HEAD
-react-error-overlay@^6.0.11:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz"
-  integrity sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==
-
-=======
->>>>>>> origin/cursor/fix-netlify-build-and-merge-to-main-4497
 react-hook-form@^7.47.0:
   version "7.62.0"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz"
@@ -10341,11 +10337,7 @@ react-remove-scroll@^2.6.3:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
 
-<<<<<<< HEAD
 react-router-dom@^6.30.1:
-=======
-react-router-dom@^6.17.0:
->>>>>>> origin/cursor/fix-netlify-build-and-merge-to-main-4497
   version "6.30.1"
   resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz"
   integrity sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==


### PR DESCRIPTION
Fix Netlify build by resolving dependency conflicts and adding SPA fallback.

The build was failing due to mixed build configurations (Vite/React Scripts), missing TypeScript compiler, and merge conflict markers in configuration files. Adding `_redirects` ensures proper client-side routing on Netlify.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e7e808a-198d-4b5b-b95f-de53779507f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e7e808a-198d-4b5b-b95f-de53779507f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

