### PR TITLE
Build nextjs application with syntax error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -60,4 +60,4 @@ const nextConfig = {
 	},
 };
 
-export default nextConfig;
+module.exports = nextConfig;


### PR DESCRIPTION
Convert `next.config.js` to CommonJS export syntax to resolve `SyntaxError: Unexpected token 'export'` during Next.js build.

The `next.config.js` file was using ES6 `export default` syntax, but Node.js was attempting to load it as a CommonJS module, leading to a syntax error. This change ensures compatibility with the build environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-dca44d04-9db5-40f1-9c86-9a738b2d73a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dca44d04-9db5-40f1-9c86-9a738b2d73a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

