### PR TITLE
Build vite app with netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,9 +19,6 @@
   NODE_OPTIONS = "--max-old-space-size=6144"
   NODE_ENV = "production"
   
-  # Disable telemetry
-  NEXT_TELEMETRY_DISABLED = "1"
-  
   # Yarn configuration
   YARN_CACHE_FOLDER = "/opt/buildhome/.yarn_cache"
   YARN_ENABLE_IMMUTABLE_INSTALLS = "false"
@@ -31,9 +28,6 @@
   directories = ["node_modules/.cache"]
 
 # Plugin configurations
-[[plugins]]
-  package = "@netlify/plugin-nextjs"
-
 [[plugins]]
   package = "netlify-plugin-cloudinary"
 

--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.39.0",
     "@tanstack/react-query": "^5.17.19",
+    "@vitejs/plugin-react": "^5.0.2",
     "axios": "^1.11.0",
     "chalk": "^5.5.0",
     "cheerio": "^1.1.2",
@@ -301,6 +302,7 @@
     "react-is": "^18.3.1",
     "resend": "^6.0.3",
     "uuid": "^13.0.0",
+    "vite": "^7.1.4",
     "web-vitals": "^5.1.0",
     "i18next": "^23.7.16",
     "i18next-browser-languagedetector": "^7.2.0",
@@ -345,7 +347,6 @@
     "@tailwindcss/postcss": "^4.1.12",
     "@tailwindcss/typography": "^0.5.16",
     "@types/react-datepicker": "^6.2.0",
-    "@vitejs/plugin-react": "^5.0.2",
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -384,8 +385,7 @@
     "tailwind-merge": "^2.2.1",
     "jsdom": "^24.0.0",
     "tailwindcss": "^3.4.17",
-    "postcss": "^8.5.6",
-    "vite": "^7.1.4"
+    "postcss": "^8.5.6"
   },
   "optionalDependencies": {
     "@magneticwatermelon/mcp-toolkit": "^1.1.4",


### PR DESCRIPTION
## Description

This pull request resolves a Netlify build failure where the `vite` command was not found during the build process.

The root cause was two-fold:
1.  `vite` and `@vitejs/plugin-react` were incorrectly listed as `devDependencies` in `package.json`. Netlify builds in `production` mode, which skips the installation of `devDependencies`, leading to the `sh: 1: vite: not found` error.
2.  The `netlify.toml` configuration included the `@netlify/plugin-nextjs` plugin, which is not applicable for a Vite-based project and was causing conflicts.

This PR addresses these issues by:
*   Moving `vite` and `@vitejs/plugin-react` to `dependencies` in `package.json` to ensure they are always installed during the build.
*   Removing the `@netlify/plugin-nextjs` plugin and the `NEXT_TELEMETRY_DISABLED` environment variable from `netlify.toml`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] CI/CD improvements

## Related Issues

N/A

## Testing

- [x] I have tested this change locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass (N/A, no specific tests for build config)
- [x] New and existing unit tests pass locally with my changes (N/A, no specific tests for build config)
- [ ] I have tested this change in a browser environment
- [ ] I have tested this change on different devices/screen sizes

Local build commands `npm run build` and `npm run build:netlify` were executed successfully, and the `dist` directory was correctly generated.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version number if appropriate
- [ ] I have updated the CHANGELOG.md if appropriate

## Screenshots

N/A

## Performance Impact

- [x] No performance impact
- [ ] Performance improvement
- [ ] Performance regression (please explain)

## Security Considerations

- [x] No security implications
- [ ] Security improvement
- [ ] Security concern (please explain)

## Accessibility

- [x] No accessibility changes
- [ ] Accessibility improvement
- [ ] Accessibility concern (please explain)

## Browser Compatibility

- [x] Tested on Chrome (N/A, build fix)
- [x] Tested on Firefox (N/A, build fix)
- [x] Tested on Safari (N/A, build fix)
- [x] Tested on Edge (N/A, build fix)
- [x] Tested on mobile browsers (N/A, build fix)

## Additional Notes

This fix ensures that the Netlify build environment correctly installs all necessary dependencies for a Vite project and uses the appropriate build configuration.

---

**Before submitting, please ensure:**

- [x] The build passes locally (`npm run build`)
- [x] All tests pass (`npm test`) (N/A, no specific tests for build config)
- [x] The code follows the project's style guidelines
- [x] You have reviewed your own code
- [x] You have tested the changes thoroughly

---
<a href="https://cursor.com/background-agent?bcId=bc-870adbb5-ea2c-43f9-8715-a82d64a51de0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-870adbb5-ea2c-43f9-8715-a82d64a51de0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

