### PR TITLE
Fix Netlify build and merge to main

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,10 +11,10 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
     // tsconfigPath: './tsconfig.json',
-  },origin/main
+  },
   eslint: {
     ignoreDuringBuilds: true,
-  },origin/main
+  },
   experimental: {
     esmExternals: false,
     optimizePackageImports: ['lucide-react', '@radix-ui/react-slot'],

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "tailwindcss": "^3.4.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
-    "vite": "^3.2.11",origin/main
+    "vite": "^3.2.11",
     "web-vitals": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Description
This PR addresses and resolves Netlify build failures by fixing syntax errors in `package.json` and `next.config.js`. Specifically, it removes extraneous `,origin/main` strings that were causing invalid JSON and JavaScript configurations. After these corrections, the build process completes successfully.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
N/A

## Testing
- [x] I have tested this change locally
- [x] All existing tests pass
- [x] New and existing unit tests pass locally with my changes

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Accessibility
- [x] No accessibility changes

## Browser Compatibility
- [x] Tested on Chrome (local build environment)

## Additional Notes
The primary issue was the presence of `,origin/main` text incorrectly embedded in JSON and JavaScript files, likely due to a merge conflict resolution error. This PR cleans up these files to restore valid syntax.

---

**Before submitting, please ensure:**
- [x] The build passes locally (`npm run build`)
- [x] All tests pass (`npm test`)
- [x] The code follows the project's style guidelines
- [x] You have reviewed your own code
- [x] You have tested the changes thoroughly

---
<a href="https://cursor.com/background-agent?bcId=bc-fcc38f54-2328-4bad-8c49-5a784d562901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fcc38f54-2328-4bad-8c49-5a784d562901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

