### PR TITLE
Check, fix, push, and merge to main

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -51,6 +51,7 @@ if (!window.performance) {
 
 // Mock PerformanceObserver
 global.PerformanceObserver = class PerformanceObserver {
+  static readonly supportedEntryTypes: readonly string[] = [];
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(_callback: PerformanceObserverCallback) {}
   disconnect() {}


### PR DESCRIPTION
Add `supportedEntryTypes` to `global.PerformanceObserver` to fix a TypeScript error.

---
<a href="https://cursor.com/background-agent?bcId=bc-4addc523-00bc-4681-ae6b-3b5c1e56810f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4addc523-00bc-4681-ae6b-3b5c1e56810f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

