### PR TITLE
Check, fix, push, and merge to main

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }

--- a/src/utils/enhancedAnalytics.ts
+++ b/src/utils/enhancedAnalytics.ts
@@ -289,9 +289,10 @@ export class EnhancedAnalytics {
       try {
         const lcpObserver = new PerformanceObserver((list) => {
           list.getEntries().forEach(entry => {
+            const lcpEntry = entry as PerformanceEntry & { element?: Element; url?: string };
             this.track('performance', 'web_vital', 'LCP', entry.startTime, {
-              element: (entry as any).element?.tagName,
-              url: (entry as any).url
+              element: lcpEntry.element?.tagName,
+              url: lcpEntry.url
             });
           });
         });


### PR DESCRIPTION
Fix TypeScript `any` type usage for `PerformanceEntry` properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b330517-ea17-430d-92b8-7701cca60196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b330517-ea17-430d-92b8-7701cca60196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

