### PR TITLE
Fix Netlify build and merge to main

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -577,10 +577,10 @@ export default function App(): React.JSX.Element {
         />
 
         {/* Advanced Performance Dashboard */}
-        <AdvancedPerformanceDashboard
+        {/* <AdvancedPerformanceDashboard
           isVisible={showAdvancedDashboard}
           onClose={() => setShowAdvancedDashboard(false)}
-        />
+        /> */}
 
         {/* Real-time Metrics */}
         {showRealTimeMetrics && (

--- a/src/components/AdvancedAnalyticsDashboard.tsx
+++ b/src/components/AdvancedAnalyticsDashboard.tsx
@@ -21,7 +21,6 @@ interface AdvancedAnalyticsDashboardProps {
   onClose: () => void;
 }
 
-const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8'];
 
 export default function AdvancedAnalyticsDashboard({ isVisible, onClose }: AdvancedAnalyticsDashboardProps) {
   const [analyticsData, setAnalyticsData] = useState<AnalyticsData | null>(null);

--- a/src/utils/lazyLoading.ts
+++ b/src/utils/lazyLoading.ts
@@ -1,4 +1,4 @@
-import { lazy, ComponentType } from 'react';
+import React, { lazy, ComponentType } from 'react';
 
 /**
  * Enhanced lazy loading utility with error boundaries and loading states


### PR DESCRIPTION
Fix Netlify build failures by resolving critical errors and linting issues.

The build was failing due to an undefined component reference (`AdvancedPerformanceDashboard`, which is now commented out), a duplicate `COLORS` variable declaration, and a missing React import in the new `lazyLoading.ts` utility file. These changes address these issues to enable successful Netlify deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec89731e-ca45-4c36-93ae-41bbadd35f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec89731e-ca45-4c36-93ae-41bbadd35f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

