### PR TITLE
Build and deploy web application with secrets detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ tsconfig.tsbuildinfo
 .yarn/cache/
 .yarn/install-state.gz
 .pnp.*
+
+# Local automation scripts (contain sensitive tokens)
+*.sh

--- a/curl_merge.sh
+++ b/curl_merge.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Simple curl-based PR merge script
-TOKEN="ghs_ARoJSTvAacep8FvSbjlT0M4kz3PRL70w75Bt"
+TOKEN="${GITHUB_TOKEN}"
 REPO="Zion-Holdings/zion.app"
 
 echo "🚀 Starting PR merge process using curl..."

--- a/merge_prs_api.sh
+++ b/merge_prs_api.sh
@@ -6,7 +6,7 @@ set -e
 echo "🚀 Starting PR merge process using GitHub API..."
 
 # GitHub API token
-TOKEN="ghs_ARoJSTvAacep8FvSbjlT0M4kz3PRL70w75Bt"
+TOKEN="${GITHUB_TOKEN}"
 REPO="Zion-Holdings/zion.app"
 
 # PRs to merge (from API response)


### PR DESCRIPTION
Remove hardcoded GitHub tokens and add `.sh` files to `.gitignore` to fix Netlify build failures and improve security.

The Netlify build was failing because its secrets scanner detected hardcoded GitHub personal access tokens in `curl_merge.sh` and `merge_prs_api.sh`. These tokens have been replaced with environment variables, and the script files are now ignored by Git to prevent future exposure of sensitive information.

---
<a href="https://cursor.com/background-agent?bcId=bc-99b954ba-f3bd-4ae4-92c1-4e43d7c6c4d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99b954ba-f3bd-4ae4-92c1-4e43d7c6c4d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

