### PR TITLE
Parse netlify configuration file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,6 @@
   command = "pnpm build:no-check"
   publish = "dist"
   command_timeout = "30m"
-  environment = { NODE_ENV = "production", CI = "true" }
 
 [build.environment]
   NODE_VERSION = "20.18.0"


### PR DESCRIPTION
Remove duplicate environment variable definition to fix Netlify build error.

The `netlify.toml` file had environment variables defined both inline within the `[build]` section and in the dedicated `[build.environment]` section, causing a "Can't redefine existing key" parsing error. This change consolidates all environment variables into the `[build.environment]` section.

---
<a href="https://cursor.com/background-agent?bcId=bc-4de2577e-300d-4e4c-9ed7-c7966d41f703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4de2577e-300d-4e4c-9ed7-c7966d41f703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

