### PR TITLE
Build script execution failure

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   # Publish prebuilt dist without running a build
-  command = "echo \"Skipping build; deploying prebuilt dist\""
+  command = "echo 'Skipping build; deploying prebuilt dist'"
   publish = "dist"
   command_timeout = "30m"
 


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes a Netlify build failure caused by incorrect shell interpretation of the `build.command` in `netlify.toml`. The semicolon within the `echo` command was being treated as a command separator, leading to a "command not found" error for "deploying".

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [x] I have tested this change locally
- [ ] I have added tests for this change
- [x] All existing tests pass
- [ ] I have tested the build process

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
The `build.command` was changed from `echo "Skipping build; deploying prebuilt dist"` to `echo 'Skipping build; deploying prebuilt dist'`. This ensures the entire string is passed as a single argument to `echo`, preventing bash from interpreting the semicolon as a command separator and resolving the `bash: line 1: deploying: command not found` error (exit code 127).

---
<a href="https://cursor.com/background-agent?bcId=bc-5bbd84e6-6e6a-4474-b85b-5ac41b8d5f75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5bbd84e6-6e6a-4474-b85b-5ac41b8d5f75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

