### PR TITLE
Fix errors and merge to main

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -65,7 +65,7 @@ Object.defineProperty(window, 'performance', {
 
 // Mock PerformanceObserver
 global.PerformanceObserver = class PerformanceObserver {
-  constructor(callback: PerformanceObserverCallback) {}
+  constructor() {}
   observe() {}
   disconnect() {}
   takeRecords() { return []; }


### PR DESCRIPTION
Fix linting error by removing unused `callback` parameter in `PerformanceObserver` mock.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cb1760d-bb6b-4eb6-9224-c0eca547f369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5cb1760d-bb6b-4eb6-9224-c0eca547f369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

