### PR TITLE
Fix errors and merge to main

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -27,6 +27,9 @@ jest.mock('react-router-dom', () => ({
   BrowserRouter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   Routes: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   Route: ({ element }: { element: React.ReactNode }) => <>{element}</>,
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string; [key: string]: unknown }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
 }));
 
 const renderApp = (component: React.ReactElement) => {


### PR DESCRIPTION
Add `Link` component to `react-router-dom` mock to fix Header component test failures.

The Header component uses `Link` from `react-router-dom`, but the existing test mock for `react-router-dom` did not provide the `Link` component, causing tests to fail with undefined component errors. This change adds a basic mock for `Link` to resolve the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e5f4778-3b4f-4efe-b794-a538ed1c24b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e5f4778-3b4f-4efe-b794-a538ed1c24b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

