### PR TITLE
Fix errors and merge to main

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowImportingTsExtensions": false,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
Update `moduleResolution` in `tsconfig.json` to `node` to resolve TypeScript errors with `lucide-react` named imports.

The previous `bundler` module resolution was causing TypeScript to incorrectly interpret `lucide-react`'s ESM exports, leading to errors where named imports were not recognized. Changing to `node` resolution correctly resolves these imports.

---
<a href="https://cursor.com/background-agent?bcId=bc-18fa52bd-eccc-4918-8621-1feae1e88f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18fa52bd-eccc-4918-8621-1feae1e88f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

