### PR TITLE
Fix errors and merge to main

### DIFF
--- a/src/seo-optimizer.ts
+++ b/src/seo-optimizer.ts
@@ -22,10 +22,10 @@ export const seoOptimizer = {
     seoOptimizer.updateMeta('keywords', keywords);
   },
   
-  trackPageView: (page: string) => {
+  trackPageView: () => {
     // Basic analytics tracking
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      (window as any).gtag('config', 'GA_MEASUREMENT_ID', {
+    if (typeof window !== 'undefined' && (window as unknown as { gtag?: unknown }).gtag) {
+      ((window as unknown as { gtag: (command: string, id: string, config: Record<string, string>) => void }).gtag)('config', 'GA_MEASUREMENT_ID', {
         page_title: document.title,
         page_location: window.location.href,
       });


### PR DESCRIPTION
Fix linting warnings by removing an unused parameter and improving type safety for `window.gtag`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9666b53-56aa-4636-ae27-0201387533ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9666b53-56aa-4636-ae27-0201387533ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

