### PR TITLE
Fix errors and merge to main

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -28,7 +28,7 @@ const App: React.FC = () => {
     performanceOptimizer.lazyLoadImages();
     // Initialize Web Vitals monitoring
     if (typeof window !== 'undefined' && 'performance' in window) {
-      const metrics = performanceOptimizer.measurePageLoad();
+      const metrics = performanceOptimizer.measurePageLoadMetrics();
       if (metrics) {
         performanceOptimizer.reportWebVitals(metrics);
       }

--- a/app/components/PerformanceDashboard.tsx
+++ b/app/components/PerformanceDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import performanceOptimizer from '../../src/utils/performanceOptimizer';
+import { performanceOptimizer } from '../../src/utils/performanceOptimizer';
 import { getErrorMetrics, isErrorRateTooHigh } from '../../utils/errorHandling';
 
 interface DashboardData {
@@ -21,12 +21,12 @@ const PerformanceDashboard: React.FC = () => {
 
   useEffect(() => {
     const updateData = () => {
-      const metrics = performanceOptimizer.getMetrics();
+      const metrics = performanceOptimizer.getPerformanceSummary();
       const performance = {
-        averageRenderTime: metrics['averageRenderTime'] || 0,
-        totalComponents: metrics['totalComponents'] || 0,
-        memoryUsage: metrics['memoryUsage'] || 0,
-        slowComponents: metrics['slowComponents'] || 0,
+        averageRenderTime: metrics.averageRenderTime || 0,
+        totalComponents: metrics.totalComponents || 0,
+        memoryUsage: metrics.memoryUsage || 0,
+        slowComponents: metrics.slowComponents || 0,
       };
       const errors = getErrorMetrics();
       const isHealthy =

--- a/app/components/PerformanceMonitor.tsx
+++ b/app/components/PerformanceMonitor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import performanceOptimizer from '../../src/utils/performanceOptimizer';
+import { performanceOptimizer } from '../../src/utils/performanceOptimizer';
 
 interface PerformanceMonitorProps {
   children: React.ReactNode;


### PR DESCRIPTION
Fix TypeScript errors by correcting `performanceOptimizer` imports and method calls.

The existing code was attempting to use `performanceOptimizer` methods (`measurePageLoad`, `getMetrics`) that did not exist, leading to TypeScript errors. Additionally, `performanceOptimizer` was incorrectly imported as a default export instead of a named export. This PR resolves these issues by updating the imports and using the correct method names (`measurePageLoadMetrics`, `getPerformanceSummary`) available on the `performanceOptimizer` instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-77766020-4dbd-4ee6-94fb-5c966d89dfb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-77766020-4dbd-4ee6-94fb-5c966d89dfb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

