### PR TITLE
Fix errors and merge to main

### DIFF
--- a/app/components/AccessibilityEnhancer.tsx
+++ b/app/components/AccessibilityEnhancer.tsx
@@ -65,7 +65,7 @@ const AccessibilityEnhancer: React.FC<AccessibilityEnhancerProps> = ({ children 
       {children}
       
       {/* Accessibility Controls - Only show in development */}
-      {process.env.NODE_ENV === 'development' && (
+      {process.env['NODE_ENV'] === 'development' && (
         <div className="fixed top-4 left-4 z-50 bg-white border border-gray-200 rounded-lg shadow-lg p-4">
           <h3 className="text-sm font-semibold text-gray-900 mb-3">
             Accessibility Controls

--- a/src/components/AccessibilityEnhancer.tsx
+++ b/src/components/AccessibilityEnhancer.tsx
@@ -165,7 +165,7 @@ const AccessibilityEnhancer: React.FC<AccessibilityEnhancerProps> = ({ children 
       {children}
       
       {/* Accessibility Controls - Only show in development */}
-      {process.env.NODE_ENV === 'development' && (
+      {process.env['NODE_ENV'] === 'development' && (
         <div className="fixed top-4 right-4 z-50 bg-white border border-gray-200 rounded-lg shadow-lg p-4">
           <h3 className="text-sm font-semibold text-gray-900 mb-3">Accessibility Controls</h3>
           

--- a/src/components/AdvancedErrorBoundary.tsx
+++ b/src/components/AdvancedErrorBoundary.tsx
@@ -74,7 +74,7 @@ class AdvancedErrorBoundary extends Component<Props, State> {
                 refreshing the page.
               </p>
             </div>
-            {process.env.NODE_ENV === 'development' && this.state.error && (
+            {process.env['NODE_ENV'] === 'development' && this.state.error && (
               <details className='mt-4'>
                 <summary className='cursor-pointer text-sm font-medium text-gray-700'>
                   Error Details (Development)

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -88,7 +88,7 @@ class Analytics {
     this.sendToAnalytics(event);
 
     // Log in development
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env['NODE_ENV'] === 'development') {
       console.log('Analytics event:', event);
     }
   }

--- a/src/utils/devUtils.ts
+++ b/src/utils/devUtils.ts
@@ -4,25 +4,25 @@
  */
 
 export const devLog = (message: string, data?: any) => {
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env['NODE_ENV'] === 'development') {
     console.log(`[DEV] ${message}`, data || '');
   }
 };
 
 export const devError = (message: string, error?: any) => {
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env['NODE_ENV'] === 'development') {
     console.error(`[DEV ERROR] ${message}`, error || '');
   }
 };
 
 export const devWarn = (message: string, data?: any) => {
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env['NODE_ENV'] === 'development') {
     console.warn(`[DEV WARN] ${message}`, data || '');
   }
 };
 
 export const measurePerformance = (name: string, fn: () => void) => {
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env['NODE_ENV'] === 'development') {
     const start = performance.now();
     fn();
     const end = performance.now();

--- a/src/utils/enhancedErrorHandler.ts
+++ b/src/utils/enhancedErrorHandler.ts
@@ -100,7 +100,7 @@ class EnhancedErrorHandler {
     }
 
     // Log to console in development
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env['NODE_ENV'] === 'development') {
       console.error('Error handled:', error, fullContext);
     }
 

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -52,12 +52,12 @@ class ErrorHandler {
     }
 
     // Log to console in development
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env['NODE_ENV'] === 'development') {
       console.error('Error logged:', errorReport);
     }
 
     // Send to external service in production
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env['NODE_ENV'] === 'production') {
       this.sendToErrorService(errorReport);
     }
   }

--- a/src/utils/performanceOptimizer.ts
+++ b/src/utils/performanceOptimizer.ts
@@ -135,7 +135,7 @@ export const measurePageLoad = (): WebVitalsMetrics | null => {
  * Report Web Vitals metrics
  */
 export const reportWebVitals = (metrics: WebVitalsMetrics): void => {
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env['NODE_ENV'] === 'development') {
     console.log('Web Vitals:', metrics);
   }
   
@@ -398,7 +398,7 @@ class PerformanceOptimizer {
     
     this.metrics.set(name, duration);
     
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env['NODE_ENV'] === 'development') {
       console.log(`Performance: ${name} took ${duration.toFixed(2)}ms`);
     }
   }
@@ -479,7 +479,7 @@ class PerformanceOptimizer {
 
   // Add Web Vitals reporting method
   reportWebVitals(metrics: WebVitalsMetrics): void {
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env['NODE_ENV'] === 'development') {
       console.log('Web Vitals:', metrics);
     }
 

--- a/src/utils/productionLogger.ts
+++ b/src/utils/productionLogger.ts
@@ -5,17 +5,17 @@
 
 export const productionLogger = {
   log: (message: string, ...args: any[]): void => {
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env['NODE_ENV'] === 'production') {
       console.log(message, ...args);
     }
   },
   error: (message: string, ...args: any[]): void => {
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env['NODE_ENV'] === 'production') {
       console.error(message, ...args);
     }
   },
   warn: (message: string, ...args: any[]): void => {
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env['NODE_ENV'] === 'production') {
       console.warn(message, ...args);
     }
   },


### PR DESCRIPTION
Fix TypeScript errors by replacing `process.env.NODE_ENV` with `process.env['NODE_ENV']`.

This resolves strict mode TypeScript errors that occurred when directly accessing properties of `process.env`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c949808e-2600-41ee-b64d-022ea600a645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c949808e-2600-41ee-b64d-022ea600a645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

