### PR TITLE
Fix errors and merge to main

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
Update PostCSS configuration to resolve Tailwind CSS version conflicts and enable successful builds.

The project had conflicting Tailwind CSS versions (v3 and v4) installed, leading to build failures due to a malformed CSS import error. Updating the PostCSS configuration to use `tailwindcss` directly, instead of `@tailwindcss/postcss`, resolved these conflicts and allowed the application to build successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe590546-781e-4466-b5f0-63b92b09841d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe590546-781e-4466-b5f0-63b92b09841d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

