### PR TITLE
Fix errors and merge to main

### DIFF
--- a/app/api.tsx
+++ b/app/api.tsx
@@ -1,5 +1,5 @@
 // import { ArrowRight, Code, ExternalLink, Shield, Zap } from 'lucide-react';
-import { ArrowRight, Code, ExternalLink, Shield, Zap } from 'lucide-react';
+import { ArrowRight, ExternalLink, Shield, Zap } from 'lucide-react';
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/app/utils/errorHandler.tsx
+++ b/app/utils/errorHandler.tsx
@@ -257,15 +257,12 @@ export class ErrorHandler {
       switch (error.severity) {
         case ErrorSeverity.CRITICAL:
         case ErrorSeverity.HIGH:
-          // eslint-disable-next-line no-console
           console.error(logMessage, error);
           break;
         case ErrorSeverity.MEDIUM:
-          // eslint-disable-next-line no-console
           console.warn(logMessage, error);
           break;
         case ErrorSeverity.LOW:
-          // eslint-disable-next-line no-console
           console.info(logMessage, error);
           break;
       }


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes linting warnings by:
- Removing an unused `Code` import from `lucide-react` in `app/api.tsx`.
- Removing redundant `eslint-disable-next-line no-console` directives in `app/utils/errorHandler.tsx`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing
- [x] I have tested this change locally
- [ ] I have added tests for this change
- [x] All existing tests pass
- [x] I have tested the build process

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
All linting, type checking, and tests are passing after these changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-1076b39b-fb4c-4466-b27d-f9b5a677300c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1076b39b-fb4c-4466-b27d-f9b5a677300c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

