### PR TITLE
Fix errors and merge to main

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -24,7 +24,7 @@ import './globals.css';
 const App: React.FC = () => {
   useEffect(() => {
     // Initialize global error handling
-    logger.lifecycle('initialized', { component: 'App' });
+    logger.lifecycle('initialized', 'App');
 
     // Initialize performance monitoring
     lazyLoadImages();
@@ -43,7 +43,7 @@ const App: React.FC = () => {
       }
     }
     
-    logger.lifecycle('performance monitoring initialized', { component: 'App' });
+    logger.lifecycle('performance monitoring initialized', 'App');
     logger.info('🚀 Zion Tech Group App initialized with comprehensive monitoring', { component: 'App' });
   }, []);
 

--- a/app/components/NewestContent2025Banner.tsx
+++ b/app/components/NewestContent2025Banner.tsx
@@ -128,6 +128,7 @@ const NewestContent2025Banner: React.FC = () => {
             <h3 className="text-xl font-bold text-white mb-2">Autonomous Systems</h3>
             <p className="text-gray-300">Intelligent automation driving enterprise efficiency</p>
           </div>
+        </div>
       </div>
     </section>
   );

--- a/app/page-optimized.tsx
+++ b/app/page-optimized.tsx
@@ -10,7 +10,6 @@ const UnifiedBanner = dynamic(() => import('./components/NewestContent2025Banner
   ssr: false
 });
 
-// @ts-expect-error - Dynamic import fallback type issue
 const ContentPromotion = dynamic(() => import('./components/UltimateBusinessIntelligence2025Banner').catch(() => ({ default: () => React.createElement(React.Fragment, null) })), {
   loading: () => <div className="animate-pulse bg-gray-200 h-64 rounded-lg"></div>,
   ssr: false

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -19,13 +19,6 @@ export enum ErrorCategory {
   UNKNOWN = 'unknown',
 }
 
-export enum ErrorSeverity {
-  LOW = 'low',
-  MEDIUM = 'medium',
-  HIGH = 'high',
-  CRITICAL = 'critical',
-}
-
 export interface ErrorInfo {
   message: string;
   stack?: string;


### PR DESCRIPTION
```
# Pull Request

## Description
This PR addresses and fixes several identified errors across the codebase to improve stability and maintainability. The changes include:
*   Adding a missing closing `</div>` tag in `NewestContent2025Banner.tsx`.
*   Removing a duplicate `ErrorSeverity` enum definition in `errorHandler.ts`.
*   Correcting `logger.lifecycle()` calls in `App.tsx` to pass a string instead of an object.
*   Removing an unused `@ts-expect-error` directive in `page-optimized.tsx`.

All linting, type-checking, and tests pass after these changes.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Related Issue
N/A

## Testing
- [x] I have tested this change locally
- [ ] I have added tests for this change
- [x] All existing tests pass
- [x] I have tested the build process (via type-check and lint)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
This PR was generated by an automated assistant. The environment is configured to handle git push and merge operations automatically.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-97df69a6-f909-4cc5-bb87-b2f6adf49f4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-97df69a6-f909-4cc5-bb87-b2f6adf49f4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

