### PR TITLE
Parse netlify configuration file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,7 +28,6 @@
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
     # Performance optimizations
     X-DNS-Prefetch-Control = "on"
-    X-Content-Type-Options = "nosniff"
     # Cache HTML for shorter time
     Cache-Control = "public, max-age=3600, s-maxage=86400"
 


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a Netlify build failure caused by a duplicate `X-Content-Type-Options` header definition in the `netlify.toml` configuration file. The redundant entry at line 31 was removed, resolving the "Can't redefine existing key" parsing error.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Related Issue

N/A

## Testing

- [x] I have tested this change locally (validated TOML syntax and file content)
- [ ] I have added tests for this change
- [x] All existing tests pass (TOML syntax validation passed)
- [ ] I have tested the build process

## Checklist

- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The Netlify build was failing with the error: "Can't redefine existing key at row 31, col 39, pos 1288: X-Content-Type-Options = "nosniff"". This was due to `X-Content-Type-Options` being defined twice in the `[[headers]]` section. The duplicate entry has been removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c12da2b-ac56-471a-a4ce-aade140743dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c12da2b-ac56-471a-a4ce-aade140743dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

