### PR TITLE
Fix errors and merge to main

### DIFF
--- a/app/components/PerformanceMonitor.tsx
+++ b/app/components/PerformanceMonitor.tsx
@@ -10,7 +10,7 @@ export default function PerformanceMonitor() {
       const measurePageLoad = () => {
         const navigation = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming
         if (navigation) {
-          const loadTime = navigation.loadEventEnd - navigation.navigationStart
+          const loadTime = navigation.loadEventEnd - navigation.fetchStart
           console.log('Page load time:', loadTime + 'ms')
           
           // Track Core Web Vitals


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses and fixes a TypeScript error in `PerformanceMonitor.tsx` and resolves merge conflicts in `AccessibilityEnhancer.tsx` and `ErrorBoundary.tsx`.

The TypeScript error was due to `navigationStart` not existing on `PerformanceNavigationTiming`, which has been corrected by using `fetchStart` instead.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Related Issue

N/A

## Testing

- [x] I have tested this change locally
- [ ] I have added tests for this change
- [x] All existing tests pass
- [x] I have tested the build process

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

## Additional Notes

- The `navigationStart` property in `PerformanceMonitor.tsx` was replaced with `fetchStart` to resolve a TypeScript error.
- All tests pass, TypeScript checks are clean, and the build is successful after these changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-694c1a86-022e-45b3-9b64-894c73ea689a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-694c1a86-022e-45b3-9b64-894c73ea689a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

