### PR TITLE
fix(site): restore /services/ai-claims-automation redirect

### DIFF
--- a/app/services/ai-claims-automation/page.tsx
+++ b/app/services/ai-claims-automation/page.tsx
@@ -1,0 +1,17 @@
+export const metadata = {
+  alternates: { canonical: '/services/ai-insurance-claims-automation/' },
+};
+
+export default function AiClaimsAutomationRedirect() {
+  return (
+    <html lang="en">
+      <head>
+        <meta httpEquiv="refresh" content="0; url=/services/ai-insurance-claims-automation/" />
+        <link rel="canonical" href="/services/ai-insurance-claims-automation/" />
+      </head>
+      <body>
+        <p>Redirecting to <a href="/services/ai-insurance-claims-automation/">AI Insurance Claims Automation</a>...</p>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
Cherry-picked redirect page so deployment/build coverage includes the missing route.