### PR TITLE
fix: move 'use client' to top in 39 tool pages

### DIFF
--- a/app/tools/base64/page.tsx
+++ b/app/tools/base64/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Base64 | Zion Tech Group',
   description: 'Free online base64 tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/box-shadow-generator/page.tsx
+++ b/app/tools/box-shadow-generator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Box Shadow Generator | Zion Tech Group',
   description: 'Free online box shadow generator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/color-blindness-simulator/page.tsx
+++ b/app/tools/color-blindness-simulator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Color Blindness Simulator | Zion Tech Group',
   description: 'Free online color blindness simulator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/color-contrast-checker/page.tsx
+++ b/app/tools/color-contrast-checker/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Color Contrast Checker | Zion Tech Group',
   description: 'Free online color contrast checker tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/color-palette-generator/page.tsx
+++ b/app/tools/color-palette-generator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Color Palette Generator | Zion Tech Group',
   description: 'Free online color palette generator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/cron-expression-explainer/page.tsx
+++ b/app/tools/cron-expression-explainer/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Cron Expression Explainer | Zion Tech Group',
   description: 'Free online cron expression explainer tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/css-gradient-generator/page.tsx
+++ b/app/tools/css-gradient-generator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Css Gradient Generator | Zion Tech Group',
   description: 'Free online css gradient generator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/css-minifier-beautifier/page.tsx
+++ b/app/tools/css-minifier-beautifier/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Css Minifier Beautifier | Zion Tech Group',
   description: 'Free online css minifier beautifier tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/currency-converter/page.tsx
+++ b/app/tools/currency-converter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Currency Converter | Zion Tech Group',
   description: 'Free online currency converter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/html-minifier-beautifier/page.tsx
+++ b/app/tools/html-minifier-beautifier/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Html Minifier Beautifier | Zion Tech Group',
   description: 'Free online html minifier beautifier tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/html-to-jsx/page.tsx
+++ b/app/tools/html-to-jsx/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Html To Jsx | Zion Tech Group',
   description: 'Free online html to jsx tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/image-color-extractor/page.tsx
+++ b/app/tools/image-color-extractor/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Image Color Extractor | Zion Tech Group',
   description: 'Free online image color extractor tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/json-diff-viewer/page.tsx
+++ b/app/tools/json-diff-viewer/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Json Diff Viewer | Zion Tech Group',
   description: 'Free online json diff viewer tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/json-formatter/page.tsx
+++ b/app/tools/json-formatter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Json Formatter | Zion Tech Group',
   description: 'Free online json formatter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/json-schema-generator/page.tsx
+++ b/app/tools/json-schema-generator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Json Schema Generator | Zion Tech Group',
   description: 'Free online json schema generator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/json-to-csv-converter/page.tsx
+++ b/app/tools/json-to-csv-converter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Json To Csv Converter | Zion Tech Group',
   description: 'Free online json to csv converter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/jwt-decoder/page.tsx
+++ b/app/tools/jwt-decoder/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Jwt Decoder | Zion Tech Group',
   description: 'Free online jwt decoder tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/lorem-ipsum-generator/page.tsx
+++ b/app/tools/lorem-ipsum-generator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Lorem Ipsum Generator | Zion Tech Group',
   description: 'Free online lorem ipsum generator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/markdown-preview/page.tsx
+++ b/app/tools/markdown-preview/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Markdown Preview | Zion Tech Group',
   description: 'Free online markdown preview tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/number-base-converter/page.tsx
+++ b/app/tools/number-base-converter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Number Base Converter | Zion Tech Group',
   description: 'Free online number base converter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/password-generator/page.tsx
+++ b/app/tools/password-generator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Password Generator | Zion Tech Group',
   description: 'Free online password generator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/password-strength-checker/page.tsx
+++ b/app/tools/password-strength-checker/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Password Strength Checker | Zion Tech Group',
   description: 'Free online password strength checker tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/port-scanner/page.tsx
+++ b/app/tools/port-scanner/page.tsx
@@ -1,9 +1,10 @@
+'use client';
 export const metadata = {
   title: 'Port Scanner | Zion Tech Group',
   description: 'Free online port scanner tool from Zion Tech Group.',
 };
 // app/tools/port-scanner/page.tsx — Free Port Scanner (client-side via public API)
-'use client';
+
 import { pingTool } from '@/data/tools_ping_client';
 
 import { useState, useEffect } from 'react';

--- a/app/tools/qr-code-generator/page.tsx
+++ b/app/tools/qr-code-generator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Qr Code Generator | Zion Tech Group',
   description: 'Free online qr code generator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/regex-tester/page.tsx
+++ b/app/tools/regex-tester/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Regex Tester | Zion Tech Group',
   description: 'Free online regex tester tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/secure-hash-generator/page.tsx
+++ b/app/tools/secure-hash-generator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Secure Hash Generator | Zion Tech Group',
   description: 'Free online secure hash generator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/service-comparison/page.tsx
+++ b/app/tools/service-comparison/page.tsx
@@ -1,9 +1,10 @@
+'use client';
 export const metadata = {
   title: 'Service Comparison | Zion Tech Group',
   description: 'Free online service comparison tool from Zion Tech Group.',
 };
 // app/tools/service-comparison/page.tsx — Full Service Comparison
-'use client';
+
 import { pingTool } from '@/data/tools_ping_client';
 
 import { useState, useMemo, useEffect } from 'react';

--- a/app/tools/service-recommender/page.tsx
+++ b/app/tools/service-recommender/page.tsx
@@ -1,9 +1,10 @@
+'use client';
 export const metadata = {
   title: 'Service Recommender | Zion Tech Group',
   description: 'Free online service recommender tool from Zion Tech Group.',
 };
 // app/tools/service-recommender/page.tsx
-'use client';
+
 import { pingTool } from '@/data/tools_ping_client';
 
 import { useState, useEffect } from 'react';

--- a/app/tools/sql-formatter/page.tsx
+++ b/app/tools/sql-formatter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Sql Formatter | Zion Tech Group',
   description: 'Free online sql formatter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/ssl-checker/page.tsx
+++ b/app/tools/ssl-checker/page.tsx
@@ -1,9 +1,10 @@
+'use client';
 export const metadata = {
   title: 'Ssl Checker | Zion Tech Group',
   description: 'Free online ssl checker tool from Zion Tech Group.',
 };
 // app/tools/ssl-checker/page.tsx — Free SSL/TLS Certificate Checker
-'use client';
+
 import { pingTool } from '@/data/tools_ping_client';
 
 import { useState, useEffect } from 'react';

--- a/app/tools/string-case-converter/page.tsx
+++ b/app/tools/string-case-converter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'String Case Converter | Zion Tech Group',
   description: 'Free online string case converter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/subnet-calculator/page.tsx
+++ b/app/tools/subnet-calculator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Subnet Calculator | Zion Tech Group',
   description: 'Free online subnet calculator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/timestamp-converter/page.tsx
+++ b/app/tools/timestamp-converter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Timestamp Converter | Zion Tech Group',
   description: 'Free online timestamp converter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/unit-converter/page.tsx
+++ b/app/tools/unit-converter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Unit Converter | Zion Tech Group',
   description: 'Free online unit converter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/url-encoder-decoder/page.tsx
+++ b/app/tools/url-encoder-decoder/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Url Encoder Decoder | Zion Tech Group',
   description: 'Free online url encoder decoder tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/uuid-generator/page.tsx
+++ b/app/tools/uuid-generator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Uuid Generator | Zion Tech Group',
   description: 'Free online uuid generator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/word-counter/page.tsx
+++ b/app/tools/word-counter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Word Counter | Zion Tech Group',
   description: 'Free online word counter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/xml-formatter-validator/page.tsx
+++ b/app/tools/xml-formatter-validator/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Xml Formatter Validator | Zion Tech Group',
   description: 'Free online xml formatter validator tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {

--- a/app/tools/yaml-json-converter/page.tsx
+++ b/app/tools/yaml-json-converter/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 export const metadata = {
   title: 'Yaml Json Converter | Zion Tech Group',
   description: 'Free online yaml json converter tool from Zion Tech Group.',
 };
-'use client';
+
 import Link from 'next/link';
 
 export default function Page() {


### PR DESCRIPTION
Minimal build fix for Next.js 16 tool pages. Moving 'use client' back above export const metadata resolves the build regression seen in Deploy/Retry/Performance workflows.