### PR TITLE
feat(seo): add App Router SEO pages for why-us, industries/financial-services, partners/reseller, case-studies/defense-ai-logistics, tools/ai-support-outsourcing-roi, services/ai-it-staff-augmentation

### DIFF
--- a/app/case-studies/defense-ai-logistics/page.tsx
+++ b/app/case-studies/defense-ai-logistics/page.tsx
@@ -1,0 +1,75 @@
+import { Metadata } from 'next';
+import SiteBreadcrumbs from '@/components/SiteBreadcrumbs';
+
+export const metadata = {
+  title: 'Defense AI Logistics Optimization | Zion Tech Group',
+  description:
+    'Defense logistics optimization with AI: predictive maintenance, route optimization, inventory planning, and mission-readiness analytics.',
+  openGraph: {
+    title: 'Defense AI Logistics Optimization',
+    description: 'AI-driven logistics optimization for defense programs.',
+    url: 'https://ziontechgroup.com/case-studies/defense-ai-logistics',
+    type: 'website',
+  },
+  alternates: { canonical: 'https://ziontechgroup.com/case-studies/defense-ai-logistics' },
+};
+
+export default function DefenseAiLogisticsPage() {
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-24 space-y-10">
+      <SiteBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Case Studies', href: '/case-studies' },
+          { label: 'Defense AI Logistics', href: '/case-studies/defense-ai-logistics' },
+        ]}
+      />
+      <header className="text-center" style={{ maxWidth: 800, margin: '0 auto' }}>
+        <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
+          <span className="bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            Defense AI Logistics Optimization
+          </span>
+        </h1>
+        <p className="text-slate-300 text-xl leading-relaxed mb-8">Defense logistics optimization with AI: predictive maintenance, route optimization, inventory planning, and mission-readiness analytics.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Request Engagement</a>
+          <a href="/case-studies/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Case Studies</a>
+          <a href="/services/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Services</a>
+        </div>
+      </header>
+
+      <section className="mt-24 grid md:grid-cols-2 gap-5">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h2 className="text-white font-semibold mb-2">Predictive maintenance</h2>
+          <p className="text-slate-300 text-sm">Reduce downtime with AI-driven equipment health and maintenance scheduling.</p>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h2 className="text-white font-semibold mb-2">Route optimization</h2>
+          <p className="text-slate-300 text-sm">Dynamic routing and load balancing for field operations and supply chains.</p>
+        </div>
+      </section>
+
+      <section className="mt-24 text-center">
+        <h2 className="text-3xl font-bold text-white mb-4">Mission-ready logistics</h2>
+        <p className="text-slate-300 mb-8 max-w-2xl mx-auto">We apply proven AI delivery models to defense programs with measurable outcomes.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Contact Us</a>
+          <a href="/partners/technology" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Technology Partners</a>
+        </div>
+      </section>
+
+      <footer className="mt-28 border-t border-slate-800 pt-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between text-sm text-slate-400">
+        <div>
+          <a className="font-semibold text-white" href="/">Zion Tech Group</a>
+          <span className="ml-2 text-slate-500">AI & IT services for modern teams</span>
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <a href="https://calendly.com/kleber-ziontechgroup" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">Book a consultation</a>
+          <a href="/about" className="hover:text-white transition-colors">About</a>
+          <a href="/contact" className="hover:text-white transition-colors">Contact</a>
+          <a href="/services" className="hover:text-white transition-colors">Services</a>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/app/industries/financial-services/page.tsx
+++ b/app/industries/financial-services/page.tsx
@@ -1,0 +1,75 @@
+import { Metadata } from 'next';
+import SiteBreadcrumbs from '@/components/SiteBreadcrumbs';
+
+export const metadata = {
+  title: 'Financial Services AI Solutions | Zion Tech Group',
+  description:
+    'AI solutions for financial services include fraud detection, risk analytics, process automation, and regulatory compliance.',
+  openGraph: {
+    title: 'Financial Services AI Solutions',
+    description: 'Fraud detection, risk analytics, process automation, and compliance for financial services.',
+    url: 'https://ziontechgroup.com/industries/financial-services',
+    type: 'website',
+  },
+  alternates: { canonical: 'https://ziontechgroup.com/industries/financial-services' },
+};
+
+export default function FinancialServicesPage() {
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-24 space-y-10">
+      <SiteBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Industries', href: '/industries' },
+          { label: 'Financial Services', href: '/industries/financial-services' },
+        ]}
+      />
+      <header className="text-center" style={{ maxWidth: 800, margin: '0 auto' }}>
+        <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
+          <span className="bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            Financial Services AI Solutions
+          </span>
+        </h1>
+        <p className="text-slate-300 text-xl leading-relaxed mb-8">AI solutions for financial services include fraud detection, risk analytics, process automation, and regulatory compliance.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Request Demo</a>
+          <a href="/services/?category=security" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Security Services</a>
+          <a href="/case-studies/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Case Studies</a>
+        </div>
+      </header>
+
+      <section className="mt-24 grid md:grid-cols-2 gap-5">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h2 className="text-white font-semibold mb-2">Fraud detection</h2>
+          <p className="text-slate-300 text-sm">Real-time anomaly detection across transactions, claims, and access patterns.</p>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h2 className="text-white font-semibold mb-2">Risk analytics</h2>
+          <p className="text-slate-300 text-sm">Portfolio, credit, and operational risk models with explainable outputs.</p>
+        </div>
+      </section>
+
+      <section className="mt-24 text-center">
+        <h2 className="text-3xl font-bold text-white mb-4">Modernize financial operations</h2>
+        <p className="text-slate-300 mb-8 max-w-2xl mx-auto">We deliver production-ready AI systems with compliance and governance built in.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Contact Us</a>
+          <a href="/pricing/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Pricing</a>
+        </div>
+      </section>
+
+      <footer className="mt-28 border-t border-slate-800 pt-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between text-sm text-slate-400">
+        <div>
+          <a className="font-semibold text-white" href="/">Zion Tech Group</a>
+          <span className="ml-2 text-slate-500">AI & IT services for modern teams</span>
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <a href="https://calendly.com/kleber-ziontechgroup" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">Book a consultation</a>
+          <a href="/about" className="hover:text-white transition-colors">About</a>
+          <a href="/contact" className="hover:text-white transition-colors">Contact</a>
+          <a href="/services" className="hover:text-white transition-colors">Services</a>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/app/partners/reseller/page.tsx
+++ b/app/partners/reseller/page.tsx
@@ -1,0 +1,75 @@
+import { Metadata } from 'next';
+import SiteBreadcrumbs from '@/components/SiteBreadcrumbs';
+
+export const metadata = {
+  title: 'Reseller Program for AI Services | Zion Tech Group',
+  description:
+    'Resellers expand AI delivery without delivery risk. Zion Tech Group provides pricing guardrails, templates, and co-selling support.',
+  openGraph: {
+    title: 'Reseller Program for AI Services',
+    description: 'Expand AI delivery without delivery risk using pricing guardrails, templates, and co-selling support.',
+    url: 'https://ziontechgroup.com/partners/reseller',
+    type: 'website',
+  },
+  alternates: { canonical: 'https://ziontechgroup.com/partners/reseller' },
+};
+
+export default function ResellerPage() {
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-24 space-y-10">
+      <SiteBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Partners', href: '/partners' },
+          { label: 'Reseller Program', href: '/partners/reseller' },
+        ]}
+      />
+      <header className="text-center" style={{ maxWidth: 800, margin: '0 auto' }}>
+        <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
+          <span className="bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            Reseller Program for AI Services
+          </span>
+        </h1>
+        <p className="text-slate-300 text-xl leading-relaxed mb-8">Resellers expand AI delivery without delivery risk. We provide pricing guardrails, templates, and co-selling support.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Apply Now</a>
+          <a href="/partners/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Partner Info</a>
+          <a href="/pricing/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Pricing</a>
+        </div>
+      </header>
+
+      <section className="mt-24 grid md:grid-cols-2 gap-5">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h2 className="text-white font-semibold mb-2">Support</h2>
+          <p className="text-slate-300 text-sm">Pricing guardrails, SOW templates, and onboarding playbooks for resellers.</p>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h2 className="text-white font-semibold mb-2">Co-selling</h2>
+          <p className="text-slate-300 text-sm">Joint discovery calls, follow-up automation, and clear escalation rules.</p>
+        </div>
+      </section>
+
+      <section className="mt-24 text-center">
+        <h2 className="text-3xl font-bold text-white mb-4">Ready to resell AI services?</h2>
+        <p className="text-slate-300 mb-8 max-w-2xl mx-auto">Tell us your market and model. We return a concrete partnership plan within days.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Apply Now</a>
+          <a href="/case-studies/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Case Studies</a>
+        </div>
+      </section>
+
+      <footer className="mt-28 border-t border-slate-800 pt-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between text-sm text-slate-400">
+        <div>
+          <a className="font-semibold text-white" href="/">Zion Tech Group</a>
+          <span className="ml-2 text-slate-500">AI & IT services for modern teams</span>
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <a href="https://calendly.com/kleber-ziontechgroup" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">Book a consultation</a>
+          <a href="/about" className="hover:text-white transition-colors">About</a>
+          <a href="/contact" className="hover:text-white transition-colors">Contact</a>
+          <a href="/services" className="hover:text-white transition-colors">Services</a>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/app/services/ai-it-staff-augmentation/page.tsx
+++ b/app/services/ai-it-staff-augmentation/page.tsx
@@ -1,0 +1,76 @@
+import { Metadata } from 'next';
+import SiteBreadcrumbs from '@/components/SiteBreadcrumbs';
+
+export const metadata = {
+  title: 'IT Staff Augmentation with AI Copilots | Zion Tech Group',
+  description:
+    'High-output staff augmentation adds AI copilots, not just seats. Zion Tech Group combines senior delivery with autonomous tooling to ship faster.',
+  openGraph: {
+    title: 'IT Staff Augmentation with AI Copilots',
+    description: 'Senior delivery paired with autonomous AI tooling for faster implementation.',
+    url: 'https://ziontechgroup.com/services/ai-it-staff-augmentation',
+    type: 'website',
+  },
+  alternates: { canonical: 'https://ziontechgroup.com/services/ai-it-staff-augmentation' },
+};
+
+export default function AiItStaffAugmentationPage() {
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-24 space-y-10">
+      <SiteBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Services', href: '/services' },
+          { label: 'IT Staff Augmentation with AI Copilots', href: '/services/ai-it-staff-augmentation' },
+        ]}
+      />
+
+      <header className="text-center" style={{ maxWidth: 800, margin: '0 auto' }}>
+        <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
+          <span className="bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            IT Staff Augmentation with AI Copilots
+          </span>
+        </h1>
+        <p className="text-slate-300 text-xl leading-relaxed mb-8">High-output staff augmentation adds AI copilots, not just seats. We combine senior delivery with autonomous tooling to ship faster.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Request Engagement</a>
+          <a href="/services/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Services</a>
+          <a href="/careers/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Careers</a>
+        </div>
+      </header>
+
+      <section className="mt-24 grid md:grid-cols-2 gap-5">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h2 className="text-white font-semibold mb-2">Engagement models</h2>
+          <p className="text-slate-300 text-sm">Fixed-scope AI proof of concept, managed support automation retainer, or embedded team augmentation.</p>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h2 className="text-white font-semibold mb-2">Delivery model</h2>
+          <p className="text-slate-300 text-sm">Senior engineers paired with AI-assisted workflows, reusable templates, and measurable acceptance criteria.</p>
+        </div>
+      </section>
+
+      <section className="mt-24 text-center">
+        <h2 className="text-3xl font-bold text-white mb-4">Ready to scale delivery?</h2>
+        <p className="text-slate-300 mb-8 max-w-2xl mx-auto">Tell us your roadmap and constraints. We return a staffing and automation plan within days.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Contact Us</a>
+          <a href="/free-consultation/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Book Consultation</a>
+        </div>
+      </section>
+
+      <footer className="mt-28 border-t border-slate-800 pt-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between text-sm text-slate-400">
+        <div>
+          <a className="font-semibold text-white" href="/">Zion Tech Group</a>
+          <span className="ml-2 text-slate-500">AI & IT services for modern teams</span>
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <a href="https://calendly.com/kleber-ziontechgroup" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">Book a consultation</a>
+          <a href="/about" className="hover:text-white transition-colors">About</a>
+          <a href="/contact" className="hover:text-white transition-colors">Contact</a>
+          <a href="/services" className="hover:text-white transition-colors">Services</a>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/app/tools/ai-support-outsourcing-roi/page.tsx
+++ b/app/tools/ai-support-outsourcing-roi/page.tsx
@@ -1,0 +1,81 @@
+import { Metadata } from 'next';
+import SiteBreadcrumbs from '@/components/SiteBreadcrumbs';
+
+export const metadata = {
+  title: 'AI Support Outsourcing ROI Calculator for Enterprise | Zion Tech Group',
+  description:
+    'Estimate AI support outsourcing ROI in minutes. Compare agent-assisted deflection, cost per ticket, and CSAT lift with Zion Tech Group numbers.',
+  openGraph: {
+    title: 'AI Support Outsourcing ROI Calculator for Enterprise',
+    description: 'Compare AI support outsourcing ROI using a practical minutes-based estimator.',
+    url: 'https://ziontechgroup.com/tools/ai-support-outsourcing-roi',
+    type: 'website',
+  },
+  alternates: { canonical: 'https://ziontechgroup.com/tools/ai-support-outsourcing-roi' },
+};
+
+export default function AiSupportOutsourcingRoiPage() {
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-24 space-y-10">
+      <SiteBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Tools', href: '/tools' },
+          { label: 'AI Support Outsourcing ROI Calculator', href: '/tools/ai-support-outsourcing-roi' },
+        ]}
+      />
+
+      <header className="text-center" style={{ maxWidth: 800, margin: '0 auto' }}>
+        <div className="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-900/20 px-3 py-1 text-xs text-emerald-300 mb-6">Free Tool</div>
+        <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
+          <span className="bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            AI Support Outsourcing ROI Calculator
+          </span>
+        </h1>
+        <p className="text-slate-300 text-xl leading-relaxed mb-8">Estimate cost savings, deflection, and quality lift for AI-assisted support operations.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Get a Proposal</a>
+          <a href="/pricing/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Pricing</a>
+          <a href="/tools/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">All Tools</a>
+        </div>
+      </header>
+
+      <section className="mt-24 grid md:grid-cols-3 gap-5">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h3 className="text-white font-semibold mb-2">Monthly ticket volume</h3>
+          <p className="text-slate-300 text-sm">Start with total tickets across all channels.</p>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h3 className="text-white font-semibold mb-2">Deflection target</h3>
+          <p className="text-slate-300 text-sm">Estimate the realistic AI-assisted resolution rate in weeks.</p>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <h3 className="text-white font-semibold mb-2">Cost per ticket</h3>
+          <p className="text-slate-300 text-sm">Use current blended cost including tooling, staffing, and management.</p>
+        </div>
+      </section>
+
+      <section className="mt-24 text-center">
+        <h2 className="text-3xl font-bold text-white mb-4">Turn this estimate into an implementation plan</h2>
+        <p className="text-slate-300 mb-8 max-w-2xl mx-auto">We provide a sequenced roadmap for triage, knowledge, and automation deployment.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="/contact/" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Get a Proposal</a>
+          <a href="/case-studies/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Case Studies</a>
+        </div>
+      </section>
+
+      <footer className="mt-28 border-t border-slate-800 pt-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between text-sm text-slate-400">
+        <div>
+          <a className="font-semibold text-white" href="/">Zion Tech Group</a>
+          <span className="ml-2 text-slate-500">AI & IT services for modern teams</span>
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <a href="https://calendly.com/kleber-ziontechgroup" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">Book a consultation</a>
+          <a href="/about" className="hover:text-white transition-colors">About</a>
+          <a href="/contact" className="hover:text-white transition-colors">Contact</a>
+          <a href="/services" className="hover:text-white transition-colors">Services</a>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/app/why-us/page.tsx
+++ b/app/why-us/page.tsx
@@ -1,0 +1,120 @@
+import { Metadata } from 'next';
+import SiteBreadcrumbs from '@/components/SiteBreadcrumbs';
+import ArticleStructuredData from '@/components/ArticleStructuredData';
+
+export const metadata = {
+  title: 'Why Zion Tech Group | AI & IT Services',
+  description:
+    'Zion Tech Group delivers measurable AI and IT outcomes: faster delivery, safer operations, lower cost, and higher revenue.',
+  openGraph: {
+    title: 'Why Zion Tech Group',
+    description: 'Outcomes-first AI/IT delivery: speed, safety, cost, revenue.',
+    url: 'https://ziontechgroup.com/why-us',
+    type: 'website',
+  },
+  alternates: { canonical: 'https://ziontechgroup.com/why-us' },
+};
+
+export default function WhyUsPage() {
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-24 space-y-10">
+      <ArticleStructuredData
+        title={metadata.title as string}
+        description={metadata.description as string}
+        canonical={metadata.alternates?.canonical as string}
+        publishedAt="2026-07-27"
+        updatedAt="2026-07-27"
+      />
+      <SiteBreadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Why Zion Tech Group', href: '/why-us' },
+        ]}
+      />
+
+      <header className="text-center" style={{ maxWidth: 800, margin: '0 auto' }}>
+        <div className="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-900/20 px-3 py-1 text-xs text-emerald-300 mb-6">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500"></span>
+          </span>
+          Outcomes-first delivery
+        </div>
+        <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
+          <span className="bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            Why Zion Tech Group
+          </span>
+        </h1>
+        <p className="text-slate-300 text-xl leading-relaxed mb-8">
+          We build AI and IT systems that deliver measurable business outcomes:
+          faster delivery, safer operations, lower cost, and higher revenue.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="tel:+13024640950" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Call Now</a>
+          <a href="https://calendly.com/kleber-ziontechgroup" target="_blank" rel="noreferrer" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Book Consultation</a>
+          <a href="/services/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">View Services</a>
+        </div>
+      </header>
+
+      <section className="mt-24 grid md:grid-cols-2 gap-5">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <div className="text-sm text-emerald-300 font-medium mb-2">Speed</div>
+          <div className="text-slate-300 text-sm">Pilots in days, not quarters.</div>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <div className="text-sm text-amber-300 font-medium mb-2">Safety</div>
+          <div className="text-slate-300 text-sm">Governance, access, and incident readiness built in.</div>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <div className="text-sm text-cyan-300 font-medium mb-2">Cost</div>
+          <div className="text-slate-300 text-sm">Cloud, process, and automation savings with measurable ROI.</div>
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+          <div className="text-sm text-pink-300 font-medium mb-2">Revenue</div>
+          <div className="text-slate-300 text-sm">Support, CX, and data systems that grow customer value.</div>
+        </div>
+      </section>
+
+      <section className="mt-24">
+        <h2 className="text-3xl font-bold text-white mb-8 text-center">What clients actually get</h2>
+        <div className="grid md:grid-cols-3 gap-5">
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+            <h3 className="text-white font-semibold mb-2">Executable roadmap</h3>
+            <p className="text-slate-300 text-sm leading-relaxed">Clear deliverables, acceptance criteria, milestones, and optional fixed-price engagement.</p>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+            <h3 className="text-white font-semibold mb-2">Production-ready systems</h3>
+            <p className="text-slate-300 text-sm leading-relaxed">AI implementations with monitoring, access control, and handoff docs, not just demos.</p>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+            <h3 className="text-white font-semibold mb-2">Measurable progress</h3>
+            <p className="text-slate-300 text-sm leading-relaxed">Weekly outcome updates, adoption signals, and cost/revenue impact when relevant.</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-24 text-center">
+        <h2 className="text-3xl font-bold text-white mb-4">Start with one short call</h2>
+        <p className="text-slate-300 mb-8 max-w-2xl mx-auto">We prepare before every conversation so the time is useful. Pick a slot that fits.</p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="https://calendly.com/kleber-ziontechgroup" target="_blank" rel="noreferrer" className="rounded-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 font-semibold">Schedule Now</a>
+          <a href="tel:+13024640950" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Call Now</a>
+          <a href="/contact/" className="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Contact Us</a>
+        </div>
+      </section>
+
+      <footer className="mt-28 border-t border-slate-800 pt-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between text-sm text-slate-400">
+        <div>
+          <a className="font-semibold text-white" href="/">Zion Tech Group</a>
+          <span className="ml-2 text-slate-500">AI & IT services for modern teams</span>
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <a href="https://calendly.com/kleber-ziontechgroup" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">Book a consultation</a>
+          <a href="/about" className="hover:text-white transition-colors">About</a>
+          <a href="/contact" className="hover:text-white transition-colors">Contact</a>
+          <a href="/services" className="hover:text-white transition-colors">Services</a>
+        </div>
+      </footer>
+    </main>
+  );
+}


### PR DESCRIPTION
Adds substantive SEO content as App Router pages to improve lead generation and partnership discovery:

- /why-us
- /industries/financial-services
- /partners/reseller
- /case-studies/defense-ai-logistics
- /tools/ai-support-outsourcing-roi
- /services/ai-it-staff-augmentation