### PR TITLE
fix(pages): promote new SEO fallback routes and add docs/why-us, financial-services, reseller, defense-logistics, ROI, staff-augmentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -83,20 +83,24 @@ jobs:
           if [ -d public ]; then
             cp -a public/. "$ARTIFACT_DIR"/
           fi
-          # Ensure SEO files exist whichever path produced them.
-          if [ ! -f "$ARTIFACT_DIR/robots.txt" ] && [ -f docs/robots.txt ]; then cp -f docs/robots.txt "$ARTIFACT_DIR/robots.txt"; fi
-          if [ ! -f "$ARTIFACT_DIR/sitemap.xml" ] && [ -f docs/sitemap.xml ]; then cp -f docs/sitemap.xml "$ARTIFACT_DIR/sitemap.xml"; fi
-          # Promote key fallback pages from docs/ to artifact root so Pages can serve them.
-          for f in \\
-            case-studies/index.html \\
-            industries/index.html \\
-            testimonials/index.html \\
-            automation/index.html \\
-            services/ai-workflow-automation/index.html \\
-            services/ai-email-intelligence/index.html \\
-            services/ai-smart-global-campaign/index.html; do
-            mkdir -p "$ARTIFACT_DIR/$(dirname "$f")"
-            if [ ! -f "$ARTIFACT_DIR/$f" ] && [ -f "docs/$f" ]; then
+          # Promote key fallback pages after all overlay copies so they always win in the artifact.
+          for f in \
+            case-studies/index.html \
+            industries/index.html \
+            testimonials/index.html \
+            automation/index.html \
+            services/ai-workflow-automation/index.html \
+            services/ai-email-intelligence/index.html \
+            services/ai-smart-global-campaign/index.html \
+            why-us/index.html \
+            products/index.html \
+            tools/ai-support-outsourcing-roi/index.html \
+            services/ai-it-staff-augmentation/index.html \
+            partners/reseller/index.html \
+            industries/financial-services/index.html \
+            case-studies/defense-ai-logistics/index.html; do
+            if [ -f "docs/$f" ]; then
+              mkdir -p "$ARTIFACT_DIR/$(dirname "$f")"
               cp -a "docs/$f" "$ARTIFACT_DIR/$f"
             fi
           done

--- a/docs/case-studies/defense-ai-logistics/index.html
+++ b/docs/case-studies/defense-ai-logistics/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Products | Zion Tech Group</title>
+  <title>Defense AI Logistics Optimization | Zion Tech Group</title>
   <meta name="robots" content="index,follow" />
-  <meta name="description" content="Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence." />
-  <meta property="og:title" content="Products | Zion Tech Group" />
-  <meta property="og:description" content="Explore Zion Tech Group AI, IT, Micro SAAS, and developer tooling products." />
-  <meta property="og:url" content="https://ziontechgroup.com/products/" />
+  <meta name="description" content="Defense logistics optimization with AI: predictive maintenance, route optimization, inventory planning, and mission-readiness analytics." />
+  <meta property="og:title" content="Defense AI Logistics Optimization | Zion Tech Group" />
+  <meta property="og:description" content="AI-driven logistics optimization for defense programs." />
+  <meta property="og:url" content="https://ziontechgroup.com/case-studies/defense-ai-logistics/" />
   <meta property="og:type" content="website" />
-  <link rel="canonical" href="https://ziontechgroup.com/products/" />
+  <link rel="canonical" href="https://ziontechgroup.com/case-studies/defense-ai-logistics/" />
   <link rel="stylesheet" href="/styles.css"/>
   <style>
     :root { font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
@@ -40,7 +40,6 @@
     .gap-3 { gap: 12px; }
     .grid { display: grid; }
     .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .rounded-xl { border-radius: 12px; }
     .rounded-2xl { border-radius: 16px; }
     .border { border: 1px solid #1e293b; }
@@ -56,48 +55,40 @@
     .text-purple-300 { color: #d8b4fe; }
     .hover\:border-white\/40:hover { border-color: rgba(255,255,255,0.4); }
     .transition-colors { transition: color 0.2s, background-color 0.2s, border-color 0.2s; }
-    @media (min-width: 768px) { .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+    @media (min-width: 768px) { .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
   </style>
 </head>
 <body>
   <main class="max-w-6xl px-6 py-24">
     <header class="text-center" style="max-width: 800px; margin: 0 auto;">
       <h1 class="text-4xl font-bold tracking-tight mb-4">
-        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">Products</span>
+        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">Defense AI Logistics Optimization</span>
       </h1>
-      <p class="text-slate-300 text-xl leading-relaxed mb-8">Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence.</p>
+      <p class="text-slate-300 text-xl leading-relaxed mb-8">Defense logistics optimization with AI: predictive maintenance, route optimization, inventory planning, and mission-readiness analytics.</p>
       <div class="flex flex-wrap justify-center gap-3">
-        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Request Demo</a>
-        <a href="/services/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Explore Services</a>
-        <a href="/free-ai-itools/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Free AI/IT Tools</a>
+        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Request Engagement</a>
+        <a href="/case-studies/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Case Studies</a>
+        <a href="/services/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Services</a>
       </div>
     </header>
 
-    <section class="mt-24 grid md:grid-cols-3 gap-5">
+    <section class="mt-24 grid md:grid-cols-2 gap-5">
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">AI Support Automation</h3>
-        <p class="text-slate-300 text-sm">Triage, knowledge retrieval, and workflow execution for faster support.</p>
-        <a href="/services/?category=ai" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h2 class="text-white font-semibold mb-2">Predictive maintenance</h2>
+        <p class="text-slate-300 text-sm">Reduce downtime with AI-driven equipment health and maintenance scheduling.</p>
       </div>
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Observability &amp; Compliance</h3>
-        <p class="text-slate-300 text-sm">Monitoring, alerting, and governance for IT operations.</p>
-        <a href="/services/?category=security" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
-      </div>
-      <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Partner Tools</h3>
-        <p class="text-slate-300 text-sm">Channel enablement, co-selling, and margin guardrails for resellers.</p>
-        <a href="/partners/" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h2 class="text-white font-semibold mb-2">Route optimization</h2>
+        <p class="text-slate-300 text-sm">Dynamic routing and load balancing for field operations and supply chains.</p>
       </div>
     </section>
 
     <section class="mt-24 text-center">
-      <h2 class="text-3xl font-bold text-white mb-4">Need a custom solution?</h2>
-      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">Tell us your goal and we will return a concrete execution plan.</p>
+      <h2 class="text-3xl font-bold text-white mb-4">Mission-ready logistics</h2>
+      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">We apply proven AI delivery models to defense programs with measurable outcomes.</p>
       <div class="flex flex-wrap justify-center gap-3">
         <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Contact Us</a>
-        <a href="tel:+13024640950" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Call Now</a>
-        <a href="/free-consultation/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Book Consultation</a>
+        <a href="/partners/technology" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Technology Partners</a>
       </div>
     </section>
 

--- a/docs/industries/financial-services/index.html
+++ b/docs/industries/financial-services/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Products | Zion Tech Group</title>
+  <title>Financial Services AI Solutions | Zion Tech Group</title>
   <meta name="robots" content="index,follow" />
-  <meta name="description" content="Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence." />
-  <meta property="og:title" content="Products | Zion Tech Group" />
-  <meta property="og:description" content="Explore Zion Tech Group AI, IT, Micro SAAS, and developer tooling products." />
-  <meta property="og:url" content="https://ziontechgroup.com/products/" />
+  <meta name="description" content="AI solutions for financial services include fraud detection, risk analytics, process automation, and regulatory compliance." />
+  <meta property="og:title" content="Financial Services AI Solutions | Zion Tech Group" />
+  <meta property="og:description" content="Fraud detection, risk analytics, process automation, and compliance for financial services." />
+  <meta property="og:url" content="https://ziontechgroup.com/industries/financial-services/" />
   <meta property="og:type" content="website" />
-  <link rel="canonical" href="https://ziontechgroup.com/products/" />
+  <link rel="canonical" href="https://ziontechgroup.com/industries/financial-services/" />
   <link rel="stylesheet" href="/styles.css"/>
   <style>
     :root { font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
@@ -40,7 +40,6 @@
     .gap-3 { gap: 12px; }
     .grid { display: grid; }
     .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .rounded-xl { border-radius: 12px; }
     .rounded-2xl { border-radius: 16px; }
     .border { border: 1px solid #1e293b; }
@@ -56,48 +55,40 @@
     .text-purple-300 { color: #d8b4fe; }
     .hover\:border-white\/40:hover { border-color: rgba(255,255,255,0.4); }
     .transition-colors { transition: color 0.2s, background-color 0.2s, border-color 0.2s; }
-    @media (min-width: 768px) { .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+    @media (min-width: 768px) { .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
   </style>
 </head>
 <body>
   <main class="max-w-6xl px-6 py-24">
     <header class="text-center" style="max-width: 800px; margin: 0 auto;">
       <h1 class="text-4xl font-bold tracking-tight mb-4">
-        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">Products</span>
+        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">Financial Services AI Solutions</span>
       </h1>
-      <p class="text-slate-300 text-xl leading-relaxed mb-8">Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence.</p>
+      <p class="text-slate-300 text-xl leading-relaxed mb-8">AI solutions for financial services include fraud detection, risk analytics, process automation, and regulatory compliance.</p>
       <div class="flex flex-wrap justify-center gap-3">
         <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Request Demo</a>
-        <a href="/services/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Explore Services</a>
-        <a href="/free-ai-itools/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Free AI/IT Tools</a>
+        <a href="/services/?category=security" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Security Services</a>
+        <a href="/case-studies/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Case Studies</a>
       </div>
     </header>
 
-    <section class="mt-24 grid md:grid-cols-3 gap-5">
+    <section class="mt-24 grid md:grid-cols-2 gap-5">
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">AI Support Automation</h3>
-        <p class="text-slate-300 text-sm">Triage, knowledge retrieval, and workflow execution for faster support.</p>
-        <a href="/services/?category=ai" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h2 class="text-white font-semibold mb-2">Fraud detection</h2>
+        <p class="text-slate-300 text-sm">Real-time anomaly detection across transactions, claims, and access patterns.</p>
       </div>
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Observability &amp; Compliance</h3>
-        <p class="text-slate-300 text-sm">Monitoring, alerting, and governance for IT operations.</p>
-        <a href="/services/?category=security" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
-      </div>
-      <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Partner Tools</h3>
-        <p class="text-slate-300 text-sm">Channel enablement, co-selling, and margin guardrails for resellers.</p>
-        <a href="/partners/" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h2 class="text-white font-semibold mb-2">Risk analytics</h2>
+        <p class="text-slate-300 text-sm">Portfolio, credit, and operational risk models with explainable outputs.</p>
       </div>
     </section>
 
     <section class="mt-24 text-center">
-      <h2 class="text-3xl font-bold text-white mb-4">Need a custom solution?</h2>
-      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">Tell us your goal and we will return a concrete execution plan.</p>
+      <h2 class="text-3xl font-bold text-white mb-4">Modernize financial operations</h2>
+      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">We deliver production-ready AI systems with compliance and governance built in.</p>
       <div class="flex flex-wrap justify-center gap-3">
         <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Contact Us</a>
-        <a href="tel:+13024640950" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Call Now</a>
-        <a href="/free-consultation/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Book Consultation</a>
+        <a href="/pricing/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Pricing</a>
       </div>
     </section>
 

--- a/docs/partners/reseller/index.html
+++ b/docs/partners/reseller/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Products | Zion Tech Group</title>
+  <title>Reseller Program for AI Services | Zion Tech Group</title>
   <meta name="robots" content="index,follow" />
-  <meta name="description" content="Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence." />
-  <meta property="og:title" content="Products | Zion Tech Group" />
-  <meta property="og:description" content="Explore Zion Tech Group AI, IT, Micro SAAS, and developer tooling products." />
-  <meta property="og:url" content="https://ziontechgroup.com/products/" />
+  <meta name="description" content="Resellers expand AI delivery without delivery risk. Zion Tech Group provides pricing guardrails, templates, and co-selling support." />
+  <meta property="og:title" content="Reseller Program for AI Services | Zion Tech Group" />
+  <meta property="og:description" content="Expand AI delivery without delivery risk using pricing guardrails, templates, and co-selling support." />
+  <meta property="og:url" content="https://ziontechgroup.com/partners/reseller/" />
   <meta property="og:type" content="website" />
-  <link rel="canonical" href="https://ziontechgroup.com/products/" />
+  <link rel="canonical" href="https://ziontechgroup.com/partners/reseller/" />
   <link rel="stylesheet" href="/styles.css"/>
   <style>
     :root { font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
@@ -40,7 +40,6 @@
     .gap-3 { gap: 12px; }
     .grid { display: grid; }
     .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .rounded-xl { border-radius: 12px; }
     .rounded-2xl { border-radius: 16px; }
     .border { border: 1px solid #1e293b; }
@@ -56,48 +55,40 @@
     .text-purple-300 { color: #d8b4fe; }
     .hover\:border-white\/40:hover { border-color: rgba(255,255,255,0.4); }
     .transition-colors { transition: color 0.2s, background-color 0.2s, border-color 0.2s; }
-    @media (min-width: 768px) { .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+    @media (min-width: 768px) { .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
   </style>
 </head>
 <body>
   <main class="max-w-6xl px-6 py-24">
     <header class="text-center" style="max-width: 800px; margin: 0 auto;">
       <h1 class="text-4xl font-bold tracking-tight mb-4">
-        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">Products</span>
+        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">Reseller Program for AI Services</span>
       </h1>
-      <p class="text-slate-300 text-xl leading-relaxed mb-8">Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence.</p>
+      <p class="text-slate-300 text-xl leading-relaxed mb-8">Resellers expand AI delivery without delivery risk. We provide pricing guardrails, templates, and co-selling support.</p>
       <div class="flex flex-wrap justify-center gap-3">
-        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Request Demo</a>
-        <a href="/services/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Explore Services</a>
-        <a href="/free-ai-itools/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Free AI/IT Tools</a>
+        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Apply Now</a>
+        <a href="/partners/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Partner Info</a>
+        <a href="/pricing/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Pricing</a>
       </div>
     </header>
 
-    <section class="mt-24 grid md:grid-cols-3 gap-5">
+    <section class="mt-24 grid md:grid-cols-2 gap-5">
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">AI Support Automation</h3>
-        <p class="text-slate-300 text-sm">Triage, knowledge retrieval, and workflow execution for faster support.</p>
-        <a href="/services/?category=ai" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h2 class="text-white font-semibold mb-2">Support</h2>
+        <p class="text-slate-300 text-sm">Pricing guardrails, SOW templates, and onboarding playbooks for resellers.</p>
       </div>
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Observability &amp; Compliance</h3>
-        <p class="text-slate-300 text-sm">Monitoring, alerting, and governance for IT operations.</p>
-        <a href="/services/?category=security" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
-      </div>
-      <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Partner Tools</h3>
-        <p class="text-slate-300 text-sm">Channel enablement, co-selling, and margin guardrails for resellers.</p>
-        <a href="/partners/" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h2 class="text-white font-semibold mb-2">Co-selling</h2>
+        <p class="text-slate-300 text-sm">Joint discovery calls, follow-up automation, and clear escalation rules.</p>
       </div>
     </section>
 
     <section class="mt-24 text-center">
-      <h2 class="text-3xl font-bold text-white mb-4">Need a custom solution?</h2>
-      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">Tell us your goal and we will return a concrete execution plan.</p>
+      <h2 class="text-3xl font-bold text-white mb-4">Ready to resell AI services?</h2>
+      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">Tell us your market and model. We return a concrete partnership plan within days.</p>
       <div class="flex flex-wrap justify-center gap-3">
-        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Contact Us</a>
-        <a href="tel:+13024640950" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Call Now</a>
-        <a href="/free-consultation/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Book Consultation</a>
+        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Apply Now</a>
+        <a href="/case-studies/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Case Studies</a>
       </div>
     </section>
 

--- a/docs/services/ai-it-staff-augmentation/index.html
+++ b/docs/services/ai-it-staff-augmentation/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Products | Zion Tech Group</title>
+  <title>IT Staff Augmentation with AI Copilots | Zion Tech Group</title>
   <meta name="robots" content="index,follow" />
-  <meta name="description" content="Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence." />
-  <meta property="og:title" content="Products | Zion Tech Group" />
-  <meta property="og:description" content="Explore Zion Tech Group AI, IT, Micro SAAS, and developer tooling products." />
-  <meta property="og:url" content="https://ziontechgroup.com/products/" />
+  <meta name="description" content="High-output staff augmentation adds AI copilots, not just seats. Zion Tech Group combines senior delivery with autonomous tooling." />
+  <meta property="og:title" content="IT Staff Augmentation with AI Copilots | Zion Tech Group" />
+  <meta property="og:description" content="Senior delivery paired with autonomous AI tooling for faster implementation." />
+  <meta property="og:url" content="https://ziontechgroup.com/services/ai-it-staff-augmentation/" />
   <meta property="og:type" content="website" />
-  <link rel="canonical" href="https://ziontechgroup.com/products/" />
+  <link rel="canonical" href="https://ziontechgroup.com/services/ai-it-staff-augmentation/" />
   <link rel="stylesheet" href="/styles.css"/>
   <style>
     :root { font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
@@ -40,7 +40,6 @@
     .gap-3 { gap: 12px; }
     .grid { display: grid; }
     .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .rounded-xl { border-radius: 12px; }
     .rounded-2xl { border-radius: 16px; }
     .border { border: 1px solid #1e293b; }
@@ -56,47 +55,39 @@
     .text-purple-300 { color: #d8b4fe; }
     .hover\:border-white\/40:hover { border-color: rgba(255,255,255,0.4); }
     .transition-colors { transition: color 0.2s, background-color 0.2s, border-color 0.2s; }
-    @media (min-width: 768px) { .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+    @media (min-width: 768px) { .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
   </style>
 </head>
 <body>
   <main class="max-w-6xl px-6 py-24">
     <header class="text-center" style="max-width: 800px; margin: 0 auto;">
       <h1 class="text-4xl font-bold tracking-tight mb-4">
-        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">Products</span>
+        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">IT Staff Augmentation with AI Copilots</span>
       </h1>
-      <p class="text-slate-300 text-xl leading-relaxed mb-8">Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence.</p>
+      <p class="text-slate-300 text-xl leading-relaxed mb-8">High-output staff augmentation adds AI copilots, not just seats. We combine senior delivery with autonomous tooling to ship faster.</p>
       <div class="flex flex-wrap justify-center gap-3">
-        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Request Demo</a>
-        <a href="/services/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Explore Services</a>
-        <a href="/free-ai-itools/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Free AI/IT Tools</a>
+        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Request Engagement</a>
+        <a href="/services/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Services</a>
+        <a href="/careers/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Careers</a>
       </div>
     </header>
 
-    <section class="mt-24 grid md:grid-cols-3 gap-5">
+    <section class="mt-24 grid md:grid-cols-2 gap-5">
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">AI Support Automation</h3>
-        <p class="text-slate-300 text-sm">Triage, knowledge retrieval, and workflow execution for faster support.</p>
-        <a href="/services/?category=ai" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h2 class="text-white font-semibold mb-2">Engagement models</h2>
+        <p class="text-slate-300 text-sm">Fixed-scope AI proof of concept, managed support automation retainer, or embedded team augmentation.</p>
       </div>
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Observability &amp; Compliance</h3>
-        <p class="text-slate-300 text-sm">Monitoring, alerting, and governance for IT operations.</p>
-        <a href="/services/?category=security" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
-      </div>
-      <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Partner Tools</h3>
-        <p class="text-slate-300 text-sm">Channel enablement, co-selling, and margin guardrails for resellers.</p>
-        <a href="/partners/" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h2 class="text-white font-semibold mb-2">Delivery model</h2>
+        <p class="text-slate-300 text-sm">Senior engineers paired with AI-assisted workflows, reusable templates, and measurable acceptance criteria.</p>
       </div>
     </section>
 
     <section class="mt-24 text-center">
-      <h2 class="text-3xl font-bold text-white mb-4">Need a custom solution?</h2>
-      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">Tell us your goal and we will return a concrete execution plan.</p>
+      <h2 class="text-3xl font-bold text-white mb-4">Ready to scale delivery?</h2>
+      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">Tell us your roadmap and constraints. We return a staffing and automation plan within days.</p>
       <div class="flex flex-wrap justify-center gap-3">
         <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Contact Us</a>
-        <a href="tel:+13024640950" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Call Now</a>
         <a href="/free-consultation/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Book Consultation</a>
       </div>
     </section>

--- a/docs/tools/ai-support-outsourcing-roi/index.html
+++ b/docs/tools/ai-support-outsourcing-roi/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Products | Zion Tech Group</title>
+  <title>AI Support Outsourcing ROI Calculator for Enterprise | Zion Tech Group</title>
   <meta name="robots" content="index,follow" />
-  <meta name="description" content="Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence." />
-  <meta property="og:title" content="Products | Zion Tech Group" />
-  <meta property="og:description" content="Explore Zion Tech Group AI, IT, Micro SAAS, and developer tooling products." />
-  <meta property="og:url" content="https://ziontechgroup.com/products/" />
+  <meta name="description" content="Estimate AI support outsourcing ROI in minutes. Compare agent-assisted deflection, cost per ticket, and CSAT lift with Zion Tech Group numbers." />
+  <meta property="og:title" content="AI Support Outsourcing ROI Calculator for Enterprise | Zion Tech Group" />
+  <meta property="og:description" content="Compare AI support outsourcing ROI using a practical minutes-based estimator." />
+  <meta property="og:url" content="https://ziontechgroup.com/tools/ai-support-outsourcing-roi/" />
   <meta property="og:type" content="website" />
-  <link rel="canonical" href="https://ziontechgroup.com/products/" />
+  <link rel="canonical" href="https://ziontechgroup.com/tools/ai-support-outsourcing-roi/" />
   <link rel="stylesheet" href="/styles.css"/>
   <style>
     :root { font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
@@ -39,7 +39,6 @@
     .items-center { align-items: center; }
     .gap-3 { gap: 12px; }
     .grid { display: grid; }
-    .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .rounded-xl { border-radius: 12px; }
     .rounded-2xl { border-radius: 16px; }
@@ -56,48 +55,45 @@
     .text-purple-300 { color: #d8b4fe; }
     .hover\:border-white\/40:hover { border-color: rgba(255,255,255,0.4); }
     .transition-colors { transition: color 0.2s, background-color 0.2s, border-color 0.2s; }
-    @media (min-width: 768px) { .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+    @media (min-width: 768px) { .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
   </style>
 </head>
 <body>
   <main class="max-w-6xl px-6 py-24">
     <header class="text-center" style="max-width: 800px; margin: 0 auto;">
+      <div class="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-900/20 px-3 py-1 text-xs text-emerald-300 mb-6">Free Tool</div>
       <h1 class="text-4xl font-bold tracking-tight mb-4">
-        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">Products</span>
+        <span style="background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; background-clip: text; color: transparent;">AI Support Outsourcing ROI Calculator</span>
       </h1>
-      <p class="text-slate-300 text-xl leading-relaxed mb-8">Zion Tech Group products span AI support automation, observability, compliance, channel partner tooling, and operational intelligence.</p>
+      <p class="text-slate-300 text-xl leading-relaxed mb-8">Estimate cost savings, deflection, and quality lift for AI-assisted support operations.</p>
       <div class="flex flex-wrap justify-center gap-3">
-        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Request Demo</a>
-        <a href="/services/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Explore Services</a>
-        <a href="/free-ai-itools/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Free AI/IT Tools</a>
+        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Get a Proposal</a>
+        <a href="/pricing/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Pricing</a>
+        <a href="/tools/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">All Tools</a>
       </div>
     </header>
 
     <section class="mt-24 grid md:grid-cols-3 gap-5">
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">AI Support Automation</h3>
-        <p class="text-slate-300 text-sm">Triage, knowledge retrieval, and workflow execution for faster support.</p>
-        <a href="/services/?category=ai" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h3 class="text-white font-semibold mb-2">Monthly ticket volume</h3>
+        <p class="text-slate-300 text-sm">Start with total tickets across all channels.</p>
       </div>
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Observability &amp; Compliance</h3>
-        <p class="text-slate-300 text-sm">Monitoring, alerting, and governance for IT operations.</p>
-        <a href="/services/?category=security" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h3 class="text-white font-semibold mb-2">Deflection target</h3>
+        <p class="text-slate-300 text-sm">Estimate the realistic AI-assisted resolution rate in weeks.</p>
       </div>
       <div class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 class="text-white font-semibold mb-2">Partner Tools</h3>
-        <p class="text-slate-300 text-sm">Channel enablement, co-selling, and margin guardrails for resellers.</p>
-        <a href="/partners/" class="text-emerald-300 text-sm mt-3 inline-block">Learn more →</a>
+        <h3 class="text-white font-semibold mb-2">Cost per ticket</h3>
+        <p class="text-slate-300 text-sm">Use current blended cost including tooling, staffing, and management.</p>
       </div>
     </section>
 
     <section class="mt-24 text-center">
-      <h2 class="text-3xl font-bold text-white mb-4">Need a custom solution?</h2>
-      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">Tell us your goal and we will return a concrete execution plan.</p>
+      <h2 class="text-3xl font-bold text-white mb-4">Turn this estimate into an implementation plan</h2>
+      <p class="text-slate-300 mb-8 max-w-2xl mx-auto">We provide a sequenced roadmap for triage, knowledge, and automation deployment.</p>
       <div class="flex flex-wrap justify-center gap-3">
-        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Contact Us</a>
-        <a href="tel:+13024640950" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Call Now</a>
-        <a href="/free-consultation/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Book Consultation</a>
+        <a href="/contact/" class="rounded-xl bg-gradient-to-r text-white px-6 py-3 font-semibold">Get a Proposal</a>
+        <a href="/case-studies/" class="rounded-xl border border-slate-700 px-6 py-3 font-semibold text-slate-100 hover:border-white/40 transition-colors">Case Studies</a>
       </div>
     </section>
 

--- a/docs/why-us/index.html
+++ b/docs/why-us/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Why Zion Tech Group | AI & IT Delivery Partner</title>
+  <meta name="description" content="We combine US-based delivery, proven AI/IT frameworks, and measurable outcomes so clients can move fast with lower risk." />
+  <link rel="canonical" href="https://ziontechgroup.com/why-us/" />
+  <meta name="robots" content="index, follow" />
+  <style>
+    :root{color-scheme:dark light}
+    *{box-sizing:border-box}
+    body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Helvetica,Arial,Apple Color Emoji,Segoe UI Emoji;background:#0b1221;color:#e2e8f0;line-height:1.6}
+    a{color:#c4b5fd;text-decoration:underline;text-underline-offset:2px}
+    .wrap{max-width:1100px;margin:0 auto;padding:28px 20px}
+    header{border-bottom:1px solid #1f2937}
+    .brand{font-weight:800;letter-spacing:-.02em;background:linear-gradient(135deg,#a78bfa,#ec4899);-webkit-background-clip:text;background-clip:text;color:transparent}
+    nav{display:flex;gap:18px;align-items:center;flex-wrap:wrap}
+    nav a{color:#cbd5e1;text-decoration:none;font-weight:600;font-size:14px}
+    nav a:hover{color:#ffffff}
+    .cta{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;border-radius:999px;background:linear-gradient(135deg,#7c3aed,#db2777);color:#fff;font-weight:700;text-decoration:none}
+    .cta.secondary{background:#0f172a;color:#e2e8f0;border:1px solid #334155}
+    h1{font-size:42px;line-height:1.15;margin:0 0 12px;font-weight:800}
+    .sub{color:#94a3b8;font-size:18px;max-width:780px}
+    .grid{display:grid;grid-template-columns:repeat(12,1fr);gap:18px;margin-top:28px}
+    .card{grid-column:span 12;background:#0f172a;border:1px solid #1f2937;border-radius:18px;padding:20px}
+    @media (min-width:760px){.card.span-6{grid-column:span 6}.card.span-4{grid-column:span 4}}
+    .footer{border-top:1px solid #1f2937;margin-top:40px;padding-top:18px;color:#94a3b8;font-size:14px}
+    ul.check{padding-left:18px;margin:10px 0 0}
+    li{margin:8px 0}
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <nav aria-label="Primary">
+        <a class="brand" href="/">Zion Tech Group</a>
+        <a href="/services/">Services</a>
+        <a href="/solutions/">Solutions</a>
+        <a href="/case-studies/">Case Studies</a>
+        <a href="/industries/">Industries</a>
+        <a href="/tools/">Free Tools</a>
+        <a href="/pricing/">Pricing</a>
+        <a class="cta" href="/contact/">Get Proposal</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="wrap">
+      <h1>Why Zion Tech Group</h1>
+      <p class="sub">A delivery partner built for speed, accountability, and measurable outcomes.</p>
+
+      <div class="grid">
+        <div class="card">
+          <div style="font-weight:700;color:#e2e8f0;margin-bottom:6px">Outcome-first delivery</div>
+          <p style="color:#cbd5e1;margin:0">We define success criteria up front, deliver in small verifiable increments, and report results instead of activity.</p>
+          <ul class="check">
+            <li>Clear acceptance criteria</li>
+            <li>Weekly progress reviews</li>
+            <li>Runbooks for handoff and ownership</li>
+          </ul>
+        </div>
+
+        <div class="card span-6">
+          <div style="font-weight:700;color:#e2e8f0;margin-bottom:6px">US-based team, global capability</div>
+          <p style="color:#cbd5e1;margin:0">Senior architects and engineers working in US hours with clear communication and predictable response times.</p>
+          <ul class="check">
+            <li>Native English communication</li>
+            <li>Real-time collaboration during US business hours</li>
+            <li>Compliance-aware engagement models</li>
+          </ul>
+        </div>
+
+        <div class="card span-6">
+          <div style="font-weight:700;color:#e2e8f0;margin-bottom:6px">AI-native execution</div>
+          <p style="color:#cbd5e1;margin:0">We use AI tools in delivery: faster documentation, smarter testing, automated monitoring, and shorter feedback loops.</p>
+          <ul class="check">
+            <li>Faster scoping and proposal turnaround</li>
+            <li>Automated validation and quality checks</li>
+            <li>Continuous improvement from telemetry</li>
+          </ul>
+        </div>
+
+        <div class="card span-6">
+          <div style="font-weight:700;color:#e2e8f0;margin-bottom:6px">Transparent partnership</div>
+          <p style="color:#cbd5e1;margin:0">No vague engagements. You get clear options, tradeoffs, and recommendations so decisions are easy.</p>
+          <ul class="check">
+            <li>Tailored proposals with timelines</li>
+            <li>Clear pricing models: fixed, retainer, or partnership</li>
+            <li>Optional same-day written summary</li>
+          </ul>
+        </div>
+
+        <div class="card span-6">
+          <div style="font-weight:700;color:#e2e8f0;margin-bottom:6px">Proven service depth</div>
+          <p style="color:#cbd5e1;margin:0">From cybersecurity to cloud optimization, our catalog spans hundreds of services with real implementation patterns.</p>
+          <ul class="check">
+            <li>Broad AI, IT, and cloud capabilities</li>
+            <li>Industry-specific experience</li>
+            <li>Fast discovery to production path</li>
+          </ul>
+        </div>
+      </div>
+
+      <div style="margin-top:28px;display:flex;flex-wrap:wrap;gap:12px;justify-content:center">
+        <a class="cta" href="/contact/">Start with a proposal</a>
+        <a class="cta secondary" href="/pricing/">See engagement models</a>
+        <a class="cta secondary" href="https://calendly.com/kleber-ziontechgroup" target="_blank" rel="noreferrer">Book a consultation</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="wrap footer">
+    <div>© <span id="year"></span> Zion Tech Group. All rights reserved.</div>
+    <div style="margin-top:8px">
+      <a href="/contact/">Contact</a> · <a href="mailto:kleber@ziontechgroup.com">Email</a> · <a href="tel:+13024640950">Call</a> · <a href="https://meet.google.com/ouu-khao-kuy">Meet</a>
+    </div>
+    <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Adds docs/ fallback pages and updates GitHub Pages workflow promotion order so new SEO routes survive artifact overlay:

- /why-us
- /products
- /tools/ai-support-outsourcing-roi
- /services/ai-it-staff-augmentation
- /partners/reseller
- /industries/financial-services
- /case-studies/defense-ai-logistics